### PR TITLE
Add registration and approval system

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -19,6 +19,7 @@ security:
             lazy: true
             provider: app_user_provider
             custom_authenticator: App\Security\AppAuthenticator
+            user_checker: App\Security\ApprovedUserChecker
             logout:
                 path: app_logout
                 target: app_login # You can set this to app_home if you want users to be redirected to the homepage after logout

--- a/migrations/Version20250708071453.php
+++ b/migrations/Version20250708071453.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250708071453 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add approved column to user';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `user` ADD approved TINYINT(1) NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE `user` DROP approved');
+    }
+}

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Form\UserType;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+class RegistrationController extends AbstractController
+{
+    #[Route('/register', name: 'app_register', methods: ['GET', 'POST'])]
+    public function register(Request $request, EntityManagerInterface $entityManager, UserPasswordHasherInterface $passwordHasher, UserRepository $userRepository): Response
+    {
+        if ($this->getUser()) {
+            return $this->redirectToRoute('app_home');
+        }
+
+        $user = new User();
+        $form = $this->createForm(UserType::class, $user, ['include_password' => true]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            if ($userRepository->findOneBy(['email' => $user->getEmail()])) {
+                $this->addFlash('error', 'Email is already taken.');
+            } else {
+                $user->setPassword(
+                    $passwordHasher->hashPassword(
+                        $user,
+                        $form->get('password')->getData()
+                    )
+                );
+                $user->setApproved(false);
+                $entityManager->persist($user);
+                $entityManager->flush();
+
+                $this->addFlash('success', 'Account created. Wait for admin approval.');
+                return $this->redirectToRoute('app_login');
+            }
+        }
+
+        return $this->render('security/register.html.twig', [
+            'registrationForm' => $form,
+        ]);
+    }
+}

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -44,6 +44,7 @@ final class UserController extends AbstractController
                     $form->get('password')->getData()
                 )
             );
+            $user->setApproved(true);
             $entityManager->persist($user);
             $entityManager->flush();
 
@@ -119,5 +120,19 @@ final class UserController extends AbstractController
         return $this->render('user/show.html.twig', [
             'user' => $user,
         ]);
+    }
+
+    #[Route('/{id}/approve', name: 'app_user_approve', methods: ['POST'])]
+    public function approve(User $user, EntityManagerInterface $entityManager, Request $request): Response
+    {
+        $this->denyAccessUnlessGranted('ROLE_ADMIN');
+
+        if ($this->isCsrfTokenValid('approve' . $user->getId(), $request->get('_token'))) {
+            $user->setApproved(true);
+            $entityManager->flush();
+            $this->addFlash('success', 'User approved');
+        }
+
+        return $this->redirectToRoute('app_user_index');
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -38,6 +38,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'boolean')]
     private bool $twoFactorEnabled = false;
 
+    #[ORM\Column(type: 'boolean')]
+    private bool $approved = false;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -126,6 +129,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setTwoFactorEnabled(bool $twoFactorEnabled): static
     {
         $this->twoFactorEnabled = $twoFactorEnabled;
+
+        return $this;
+    }
+
+    public function isApproved(): bool
+    {
+        return $this->approved;
+    }
+
+    public function setApproved(bool $approved): static
+    {
+        $this->approved = $approved;
 
         return $this;
     }

--- a/src/Security/ApprovedUserChecker.php
+++ b/src/Security/ApprovedUserChecker.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class ApprovedUserChecker implements UserCheckerInterface
+{
+    public function checkPreAuth(UserInterface $user): void
+    {
+        if ($user instanceof User && !$user->isApproved()) {
+            throw new CustomUserMessageAccountStatusException('Your account is awaiting admin approval.');
+        }
+    }
+
+    public function checkPostAuth(UserInterface $user): void
+    {
+    }
+}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -33,7 +33,10 @@
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
 
                 <button type="submit" class="btn btn-primary w-100">Sign in</button>
-            </form>
+                </form>
+                <div class="text-center mt-2">
+                    <a href="{{ path('app_register') }}" class="small">Create account</a>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/security/register.html.twig
+++ b/templates/security/register.html.twig
@@ -1,0 +1,41 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Register{% endblock %}
+
+{% block body %}
+    <div class="row justify-content-center mt-5">
+        <div class="col-md-5 col-lg-4">
+            <div class="card login-card p-4">
+                <h1 class="text-center mb-4">Create Account</h1>
+                {{ form_start(registrationForm) }}
+                {{ form_row(registrationForm.email) }}
+                {{ form_row(registrationForm.roles) }}
+                <div class="mb-3 position-relative">
+                    {{ form_label(registrationForm.password) }}
+                    <div class="input-group">
+                        {{ form_widget(registrationForm.password, {'attr': {'class': 'form-control', 'id':'regPassword'}}) }}
+                        <button class="btn btn-outline-secondary" type="button" id="togglePassword">
+                            <span class="material-icons">visibility</span>
+                        </button>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Register</button>
+                {{ form_end(registrationForm) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block javascripts %}
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const toggle = document.getElementById('togglePassword');
+            const password = document.getElementById('regPassword');
+            if (toggle && password) {
+                toggle.addEventListener('click', () => {
+                    password.type = password.type === 'password' ? 'text' : 'password';
+                });
+            }
+        });
+    </script>
+{% endblock %}

--- a/templates/user/index.html.twig
+++ b/templates/user/index.html.twig
@@ -13,6 +13,7 @@
                 <th>Id</th>
                 <th>Email</th>
                 <th>Roles</th>
+                <th>Approved</th>
                 <th>Actions</th>
             </tr>
             </thead>
@@ -22,16 +23,24 @@
                     <td>{{ user.id }}</td>
                     <td>{{ user.email }}</td>
                     <td>{{ user.roles|join(', ') }}</td>
+                    <td>{{ user.approved ? 'Yes' : 'No' }}</td>
                     <td>
                         <a href="{{ path('app_user_show', {'id': user.id}) }}" class="btn btn-sm btn-outline-secondary">Show</a>
                         <a href="{{ path('app_user_edit', {'id': user.id}) }}" class="btn btn-sm btn-outline-primary">Edit</a>
                         <a href="{{ path('app_user_change_password', {'id': user.id}) }}" class="btn btn-sm btn-outline-primary">Password</a>
                         <a href="{{ path('app_user_2fa', {'id': user.id}) }}" class="btn btn-sm btn-outline-primary">Add 2FA</a>
+                        {% if not user.approved %}
+                            <form method="post" action="{{ path('app_user_approve', {'id': user.id}) }}" class="d-inline">
+                                <input type="hidden" name="_token" value="{{ csrf_token('approve' ~ user.id) }}">
+                                <button class="btn btn-sm btn-success">Approve</button>
+                            </form>
+                        {% endif %}
                     </td>
                 </tr>
             {% else %}
                 <tr>
                     <td class="text-center">No records found</td>
+                    <td></td>
                     <td></td>
                     <td></td>
                     <td></td>

--- a/templates/user/show.html.twig
+++ b/templates/user/show.html.twig
@@ -22,6 +22,10 @@
                 <td>{{ user.roles ? user.roles|json_encode : 'N/A' }}</td>
             </tr>
             <tr>
+                <th>Approved</th>
+                <td>{{ user.approved ? 'Yes' : 'No' }}</td>
+            </tr>
+            <tr>
                 <th>Password</th>
                 <td>{{ user.password ? '******' : 'N/A' }}</td> {# For security, don't display raw password #}
             </tr>


### PR DESCRIPTION
## Summary
- add `approved` property to `User` entity with migration
- create `RegistrationController` for public account signup
- ensure admins approve accounts via new button in user list
- block login until account approval using `ApprovedUserChecker`
- tweak login page with register link and new register page

## Testing
- `php --version` *(fails: command not found)*
- `vendor/bin/phpcs` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_686fb70df5cc8331b326f9225b710a1a