### PR TITLE
Improve register form styling and JS

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -172,6 +172,16 @@ table.table tbody td {
     margin-bottom: .25rem;
 }
 
+.apple-card .input-group .btn {
+    border-radius: 8px;
+    border-color: #ced4da;
+    background-color: #f5f5f7;
+    color: #0071e3;
+}
+.apple-card .input-group .form-control {
+    border-right: 0;
+}
+
 /* SweetAlert2 minimal look */
 .swal2-popup.apple-swal {
     border-radius: 12px;

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -65,6 +65,9 @@
                         <li class="nav-item">
                             <a class="nav-link" href="{{ path('app_login') }}">Login</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ path('app_register') }}">Register</a>
+                        </li>
                     {% endif %}
                 </ul>
             </div>

--- a/templates/security/register.html.twig
+++ b/templates/security/register.html.twig
@@ -20,7 +20,7 @@
                 </div>
                 <div class="mb-3">
                     {{ form_label(registrationForm.roles) }}
-                    {{ form_widget(registrationForm.roles, {'attr': {'class': 'form-control'}}) }}
+                    {{ form_widget(registrationForm.roles, {'attr': {'class': 'form-control js-roles-select'}}) }}
                 </div>
                 <div class="mb-3 position-relative">
                     {{ form_label(registrationForm.password) }}
@@ -40,21 +40,21 @@
 
 {% block javascripts %}
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const toggle = document.getElementById('togglePassword');
-            const password = document.getElementById('regPassword');
+        document.addEventListener('DOMContentLoaded', function () {
+            var toggle = document.getElementById('togglePassword');
+            var password = document.getElementById('regPassword');
             if (toggle && password) {
-                toggle.addEventListener('click', () => {
-                    const isHidden = password.type === 'password';
+                toggle.addEventListener('click', function () {
+                    var isHidden = password.type === 'password';
                     password.type = isHidden ? 'text' : 'password';
-                    const icon = toggle.querySelector('.material-icons');
+                    var icon = toggle.querySelector('.material-icons');
                     if (icon) {
                         icon.textContent = isHidden ? 'visibility_off' : 'visibility';
                     }
                 });
             }
 
-            const select = document.querySelector('.js-roles-select');
+            var select = document.querySelector('.js-roles-select');
             if (select && window.TomSelect) {
                 new TomSelect(select, {plugins: ['remove_button']});
             }

--- a/templates/security/register.html.twig
+++ b/templates/security/register.html.twig
@@ -34,18 +34,17 @@
 
 {% block javascripts %}
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const toggle = document.getElementById('togglePassword');
-            const password = document.getElementById('regPassword');
-            if (toggle && password) {
-                toggle.addEventListener('click', () => {
-                    password.type = password.type === 'password' ? 'text' : 'password';
-                });
-            }
-            const select = document.querySelector('.js-roles-select');
-            if (select) {
-                new TomSelect(select, {plugins: ['remove_button']});
-            }
-        });
+        const toggle = document.getElementById('togglePassword');
+        const password = document.getElementById('regPassword');
+        if (toggle && password) {
+            toggle.addEventListener('click', () => {
+                password.type = password.type === 'password' ? 'text' : 'password';
+            });
+        }
+
+        const select = document.querySelector('.js-roles-select');
+        if (select && window.TomSelect) {
+            new TomSelect(select, {plugins: ['remove_button']});
+        }
     </script>
 {% endblock %}

--- a/templates/security/register.html.twig
+++ b/templates/security/register.html.twig
@@ -14,8 +14,14 @@
                     <div class="alert alert-success">{{ message }}</div>
                 {% endfor %}
                 {{ form_start(registrationForm) }}
-                {{ form_row(registrationForm.email) }}
-                {{ form_row(registrationForm.roles) }}
+                <div class="mb-3">
+                    {{ form_label(registrationForm.email) }}
+                    {{ form_widget(registrationForm.email, {'attr': {'class': 'form-control', 'id': 'regEmail'}}) }}
+                </div>
+                <div class="mb-3">
+                    {{ form_label(registrationForm.roles) }}
+                    {{ form_widget(registrationForm.roles, {'attr': {'class': 'form-control'}}) }}
+                </div>
                 <div class="mb-3 position-relative">
                     {{ form_label(registrationForm.password) }}
                     <div class="input-group">
@@ -34,17 +40,24 @@
 
 {% block javascripts %}
     <script>
-        const toggle = document.getElementById('togglePassword');
-        const password = document.getElementById('regPassword');
-        if (toggle && password) {
-            toggle.addEventListener('click', () => {
-                password.type = password.type === 'password' ? 'text' : 'password';
-            });
-        }
+        document.addEventListener('DOMContentLoaded', () => {
+            const toggle = document.getElementById('togglePassword');
+            const password = document.getElementById('regPassword');
+            if (toggle && password) {
+                toggle.addEventListener('click', () => {
+                    const isHidden = password.type === 'password';
+                    password.type = isHidden ? 'text' : 'password';
+                    const icon = toggle.querySelector('.material-icons');
+                    if (icon) {
+                        icon.textContent = isHidden ? 'visibility_off' : 'visibility';
+                    }
+                });
+            }
 
-        const select = document.querySelector('.js-roles-select');
-        if (select && window.TomSelect) {
-            new TomSelect(select, {plugins: ['remove_button']});
-        }
+            const select = document.querySelector('.js-roles-select');
+            if (select && window.TomSelect) {
+                new TomSelect(select, {plugins: ['remove_button']});
+            }
+        });
     </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- polish apple style form styles for input groups
- fix password visibility toggle logic on registration form

## Testing
- `composer --no-interaction run-script test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68702319a1e88331980713a56e179095