### PR TITLE
Track queue/log authors

### DIFF
--- a/migrations/Version20250708071455.php
+++ b/migrations/Version20250708071455.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250708071455 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add author column to shopfully tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shopfully_preset ADD author VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE shopfully_log ADD author VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shopfully_preset DROP author');
+        $this->addSql('ALTER TABLE shopfully_log DROP author');
+    }
+}

--- a/src/Command/ShopfullyWorkerCommand.php
+++ b/src/Command/ShopfullyWorkerCommand.php
@@ -77,6 +77,7 @@ class ShopfullyWorkerCommand extends Command
         $this->em->flush();
 
         try {
+            $this->crawler->setAuthor($preset->getAuthor());
             $this->crawler->crawl($preset->getData());
             $preset->setStatus('finished');
             $preset->setErrorMessage(null);

--- a/src/Controller/ShopfullyController.php
+++ b/src/Controller/ShopfullyController.php
@@ -51,6 +51,7 @@ class ShopfullyController extends AbstractController
             $preset = new ShopfullyPreset();
             $preset->setCreatedAt(new \DateTime());
             $preset->setScheduledAt(new \DateTime());
+            $preset->setAuthor($this->getUser()?->getUserIdentifier());
             $preset->setData($data);
             $preset->setStatus('pending');
             $em->persist($preset);

--- a/src/CrawlerScripts/ShopfullyCrawler.php
+++ b/src/CrawlerScripts/ShopfullyCrawler.php
@@ -18,6 +18,7 @@ class ShopfullyCrawler
     private ShopfullyService $shopfullyService;
     private IprotoService $iprotoService;
     private string $company;
+    private ?string $author = null;
 
     public function __construct(
         EntityManagerInterface $em,
@@ -27,6 +28,17 @@ class ShopfullyCrawler
         $this->em = $em;
         $this->shopfullyService = $shopfullyService;
         $this->iprotoService = $iprotoService;
+    }
+
+    public function setAuthor(?string $author): self
+    {
+        $this->author = $author;
+        return $this;
+    }
+
+    public function getAuthor(): ?string
+    {
+        return $this->author;
     }
 
     public function crawl(array $brochuresData): void
@@ -83,6 +95,7 @@ class ShopfullyCrawler
         $log->setErrorsCount($import['errorsCount'] ?? 0);
         $log->setImportId($import['id']);
         $log->setCreatedAt(new \DateTime());
+        $log->setAuthor($this->author);
 
         $this->em->persist($log);
         $this->em->flush();

--- a/src/Entity/ShopfullyLog.php
+++ b/src/Entity/ShopfullyLog.php
@@ -14,6 +14,9 @@ class ShopfullyLog
     #[ORM\Column]
     private ?int $id = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $author = null;
+
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private ?\DateTimeInterface $createdAt = null;
 
@@ -31,6 +34,17 @@ class ShopfullyLog
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $status = null;
+
+    public function getAuthor(): ?string
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?string $author): static
+    {
+        $this->author = $author;
+        return $this;
+    }
 
 
 

--- a/src/Entity/ShopfullyPreset.php
+++ b/src/Entity/ShopfullyPreset.php
@@ -14,6 +14,9 @@ class ShopfullyPreset
     #[ORM\Column]
     private ?int $id = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $author = null;
+
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private ?\DateTimeInterface $createdAt = null;
 
@@ -31,6 +34,17 @@ class ShopfullyPreset
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $errorMessage = null;
+
+    public function getAuthor(): ?string
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?string $author): self
+    {
+        $this->author = $author;
+        return $this;
+    }
 
     public function getId(): ?int
     {

--- a/templates/shopfully/wizard.html.twig
+++ b/templates/shopfully/wizard.html.twig
@@ -213,6 +213,7 @@
                                     <tr>
                                         <th>ID</th>
                                         <th>Created</th>
+                                        <th>Author</th>
                                         <th>Scheduled</th>
                                         <th>Executed</th>
                                         <th>Status</th>
@@ -224,6 +225,7 @@
                                         <tr class="{% if p.status == 'failed' %}table-danger{% endif %}">
                                             <td>{{ p.id }}</td>
                                             <td>{{ p.createdAt ? p.createdAt|date('Y-m-d H:i:s') : '' }}</td>
+                                            <td>{{ p.author ? p.author|split('@')[0] : 'Unknown' }}</td>
                                             <td>{{ p.scheduledAt ? p.scheduledAt|date('Y-m-d H:i:s') : '' }}</td>
                                             <td>{{ p.executedAt ? p.executedAt|date('Y-m-d H:i:s') : '' }}</td>
                                             <td>
@@ -262,6 +264,7 @@
                         <tr>
                             <th>ID</th>
                             <th>Created At</th>
+                            <th>Author</th>
                             <th>Iproto ID</th>
                             <th>Locale</th>
                             <th>Status</th>
@@ -277,6 +280,7 @@
                         <tr>
                             <td>{{ log.id }}</td>
                             <td>{{ log.createdAt ? log.createdAt|date('Y-m-d H:i:s') : '' }}</td>
+                            <td>{{ log.author ? log.author|split('@')[0] : 'Unknown' }}</td>
                             <td>
                                 <a target="_blank" href="https://business-v2.offerista.com/redirect?owner_id={{ get_owner_id_by_locale(log.locale|default(''))|default('0') }}&path=/customers/{{ log.iprotoId }}/"
                                    class="d-inline-flex align-items-center gap-1 text-decoration-none">

--- a/tests/CrawlerScripts/ShopfullyCrawlerTest.php
+++ b/tests/CrawlerScripts/ShopfullyCrawlerTest.php
@@ -90,6 +90,7 @@ class ShopfullyCrawlerTest extends TestCase
         $em->expects($this->once())->method('flush');
 
         $crawler = new ShopfullyCrawler($em, $shopfullyService, $iprotoService);
+        $crawler->setAuthor('tester@example.com');
         $refProp = new \ReflectionProperty($crawler, 'company');
         $refProp->setAccessible(true);
         $refProp->setValue($crawler, 7);
@@ -105,6 +106,7 @@ class ShopfullyCrawlerTest extends TestCase
         $this->assertSame(7, $logs[0]->getIprotoId());
         $this->assertSame($formData, $logs[0]->getData());
         $this->assertSame(0, $logs[0]->getReimportCount());
+        $this->assertSame('tester@example.com', $logs[0]->getAuthor());
     }
 
     public function testCrawlRunsThroughFlow(): void


### PR DESCRIPTION
## Summary
- add `author` field to Shopfully log and preset entities
- persist author when queueing presets and logging
- pass author through worker and crawler
- display author columns in wizard queue and log tables
- update crawler tests
- include migration to add new columns

## Testing
- `vendor/bin/simple-phpunit`
- `vendor/bin/phpcs --standard=PSR12 src/Entity/ShopfullyLog.php src/Entity/ShopfullyPreset.php src/CrawlerScripts/ShopfullyCrawler.php src/Command/ShopfullyWorkerCommand.php src/Controller/ShopfullyController.php templates/shopfully/wizard.html.twig tests/CrawlerScripts/ShopfullyCrawlerTest.php`

------
https://chatgpt.com/codex/tasks/task_b_6874afa6035c83319b7308715bf74c44