### PR TITLE
Handle product names returned as strings

### DIFF
--- a/src/Service/BrochureLinkerService.php
+++ b/src/Service/BrochureLinkerService.php
@@ -179,23 +179,41 @@ class BrochureLinkerService
 
             if (is_array($pageProducts)) {
                 foreach ($pageProducts as $p) {
-                    if (!is_array($p)) {
-                        continue;
+                    $normalized = $this->normalizeProduct($p, $page['page'], $page['blocks']);
+                    if ($normalized !== null) {
+                        $products[] = $normalized;
                     }
-
-                    $name = $p['product'] ?? $p['name'] ?? null;
-                    if (empty($name)) {
-                        continue;
-                    }
-
-                    $p['product'] = $name;
-                    $p['page'] = $page['page'];
-                    $p['position'] = $this->findPosition($page['blocks'], $name);
-                    $products[] = $p;
                 }
             }
         }
         return $products;
+    }
+
+    /**
+     * Normalize a product entry returned by ChatGPT into a consistent structure.
+     *
+     * @param mixed $item
+     * @param int   $page
+     * @param array $blocks
+     */
+    private function normalizeProduct(mixed $item, int $page, array $blocks): ?array
+    {
+        if (is_string($item)) {
+            $item = ['product' => $item];
+        } elseif (!is_array($item)) {
+            return null;
+        }
+
+        $name = $item['product'] ?? $item['name'] ?? null;
+        if (empty($name)) {
+            return null;
+        }
+
+        $item['product'] = $name;
+        $item['page'] = $page;
+        $item['position'] = $this->findPosition($blocks, $name);
+
+        return $item;
     }
 
     /**

--- a/tests/Service/BrochureLinkerServiceNormalizeProductTest.php
+++ b/tests/Service/BrochureLinkerServiceNormalizeProductTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\BrochureLinkerService;
+use PHPUnit\Framework\TestCase;
+
+class BrochureLinkerServiceNormalizeProductTest extends TestCase
+{
+    private function invokeNormalize(mixed $item): ?array
+    {
+        $ref = new \ReflectionClass(BrochureLinkerService::class);
+        $svc = $ref->newInstanceWithoutConstructor();
+        $method = $ref->getMethod('normalizeProduct');
+        $method->setAccessible(true);
+        return $method->invoke($svc, $item, 1, []);
+    }
+
+    public function testHandlesStringProduct(): void
+    {
+        $result = $this->invokeNormalize('Milk');
+        $this->assertNotNull($result);
+        $this->assertSame('Milk', $result['product']);
+        $this->assertSame(1, $result['page']);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize AI product detections allowing plain string entries
- cover normalization with unit test

## Testing
- `./vendor/bin/simple-phpunit`
- `vendor/bin/phpcs`


------
https://chatgpt.com/codex/tasks/task_b_68a459ee9ea083319c1e9a618ee4409b