### PR TITLE
Handle additional product name keys

### DIFF
--- a/src/Service/BrochureLinkerService.php
+++ b/src/Service/BrochureLinkerService.php
@@ -204,7 +204,12 @@ class BrochureLinkerService
             return null;
         }
 
-        $name = $item['product'] ?? $item['name'] ?? null;
+        $name = $item['product']
+            ?? $item['name']
+            ?? $item['title']
+            ?? $item['product_name']
+            ?? $item['productName']
+            ?? null;
         if (empty($name)) {
             return null;
         }

--- a/tests/Service/BrochureLinkerServiceNormalizeProductTest.php
+++ b/tests/Service/BrochureLinkerServiceNormalizeProductTest.php
@@ -23,4 +23,26 @@ class BrochureLinkerServiceNormalizeProductTest extends TestCase
         $this->assertSame('Milk', $result['product']);
         $this->assertSame(1, $result['page']);
     }
+
+    /**
+     * @dataProvider productNameProvider
+     */
+    public function testHandlesArrayWithVariousNameKeys(array $input): void
+    {
+        $result = $this->invokeNormalize($input);
+        $this->assertNotNull($result);
+        $this->assertSame('Bread', $result['product']);
+        $this->assertSame(1, $result['page']);
+    }
+
+    public function productNameProvider(): array
+    {
+        return [
+            [['product' => 'Bread']],
+            [['name' => 'Bread']],
+            [['title' => 'Bread']],
+            [['product_name' => 'Bread']],
+            [['productName' => 'Bread']],
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- allow BrochureLinkerService to accept alternative product name fields such as `title`, `product_name`, and `productName`
- expand tests covering product name normalization

## Testing
- `./bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_68aeb501ddcc833188096689e611765e