### PR TITLE
Handle import failures when duplicating brochures

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,6 +23,7 @@ services:
             $ftpPassword: '%env(FTP_PASSWORD)%'  # Bind the FTP password environment variable
             $ftpPort: '%env(int:FTP_PORT)%'      # Bind the FTP port as an integer
             $csvDir: '%kernel.project_dir%/public/csv' # Bind the CSV directory for CsvService
+            $brochurePdfDir: '%kernel.project_dir%/public/pdf'
             $awsKey: '%env(AWS_ACCESS_KEY_ID)%'
             $awsSecret: '%env(AWS_SECRET_ACCESS_KEY)%'
             $region: '%env(AWS_REGION)%'

--- a/public/css/booking-wizard.css
+++ b/public/css/booking-wizard.css
@@ -434,6 +434,61 @@
     box-shadow: 0 10px 20px rgba(10, 132, 255, 0.22);
 }
 
+.brochure-action-stores {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    min-width: 260px;
+    max-width: 340px;
+    background: rgba(255, 255, 255, 0.75);
+    border: 1px solid rgba(214, 220, 240, 0.65);
+    border-radius: 16px;
+    padding: 0.75rem 1rem 0.9rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.brochure-action-stores .form-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6b7280;
+    margin-bottom: 0;
+}
+
+.brochure-action-stores .select2-container .select2-selection--multiple {
+    border-radius: 14px;
+    border-color: rgba(208, 214, 230, 0.9);
+    min-height: 42px;
+    display: flex;
+    align-items: center;
+    padding: 0.35rem;
+    gap: 0.25rem;
+    background: linear-gradient(135deg, rgba(244, 246, 251, 0.7), rgba(255, 255, 255, 0.95));
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.brochure-action-stores .select2-container--default .select2-selection--multiple .select2-selection__choice {
+    border-radius: 999px;
+    border: none;
+    padding: 0.2rem 0.65rem;
+    background: rgba(10, 132, 255, 0.12);
+    color: #0a84ff;
+    font-weight: 600;
+    font-size: 0.78rem;
+}
+
+.brochure-action-stores .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+    color: #0a84ff;
+    margin-right: 0.35rem;
+    font-weight: 700;
+}
+
+.brochure-action-stores .form-text {
+    font-size: 0.75rem;
+    color: #6b7280;
+}
+
 #brochure-action-feedback {
     margin-top: 1rem;
     border-radius: 18px;

--- a/public/css/booking-wizard.css
+++ b/public/css/booking-wizard.css
@@ -234,6 +234,123 @@
     box-shadow: 0 20px 48px rgba(15, 23, 42, 0.08);
 }
 
+.table-card-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+    padding: 0.75rem 1rem;
+    background: linear-gradient(145deg, rgba(244, 246, 252, 0.85), rgba(255, 255, 255, 0.92));
+    border: 1px solid rgba(217, 223, 238, 0.6);
+    border-radius: 18px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 12px 28px rgba(15, 23, 42, 0.05);
+}
+
+.table-card-filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.table-card-filter-group .form-label {
+    font-size: 0.85rem;
+    color: #1d1d1f;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    margin-bottom: 0;
+}
+
+.table-card-filter-group .form-select {
+    min-width: 210px;
+    border-radius: 14px;
+    border: 1px solid rgba(208, 214, 230, 0.85);
+    background: rgba(248, 250, 255, 0.95);
+    box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
+    padding: 0.45rem 2rem 0.45rem 0.85rem;
+    font-size: 0.9rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.table-card-filter-group .form-select:focus {
+    border-color: rgba(10, 132, 255, 0.55);
+    background: #ffffff;
+    box-shadow: 0 0 0 0.35rem rgba(10, 132, 255, 0.18);
+}
+
+.filter-pill-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.filter-pill {
+    position: relative;
+}
+
+.filter-pill-input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.filter-pill-label {
+    display: inline-block;
+    padding: 0.35rem 1.05rem;
+    border-radius: 999px;
+    background: rgba(240, 244, 255, 0.88);
+    color: #1d1d1f;
+    font-size: 0.85rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    border: 1px solid rgba(206, 214, 232, 0.9);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75), 0 6px 16px rgba(15, 23, 42, 0.08);
+    cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+    user-select: none;
+}
+
+.filter-pill-label:hover {
+    transform: translateY(-1px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75), 0 10px 22px rgba(15, 23, 42, 0.12);
+}
+
+.filter-pill-input:checked + .filter-pill-label {
+    background: linear-gradient(145deg, rgba(10, 132, 255, 0.96), rgba(0, 122, 255, 0.92));
+    color: #ffffff;
+    border-color: transparent;
+    box-shadow: 0 14px 28px rgba(10, 132, 255, 0.26);
+}
+
+.filter-pill-input:checked + .filter-pill-label:hover {
+    box-shadow: 0 18px 32px rgba(10, 132, 255, 0.28);
+}
+
+.filter-pill-input:focus-visible + .filter-pill-label {
+    outline: none;
+    box-shadow: 0 0 0 0.35rem rgba(10, 132, 255, 0.22);
+}
+
+.table-card-filter-reset .btn {
+    color: var(--wizard-primary);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    border-radius: 999px;
+    padding: 0.15rem 0.5rem;
+    transition: color 0.2s ease;
+}
+
+.table-card-filter-reset .btn:hover,
+.table-card-filter-reset .btn:focus {
+    color: rgba(0, 102, 204, 0.95);
+    text-decoration: none;
+}
+
+.table-card-filter-reset .btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 0.35rem rgba(10, 132, 255, 0.18);
+}
+
 .table-card .table {
     margin-bottom: 0;
     color: #1f2937;
@@ -434,6 +551,10 @@
     box-shadow: 0 10px 20px rgba(10, 132, 255, 0.22);
 }
 
+.table-card-filter-reset {
+    margin-left: auto;
+}
+
 .brochure-action-stores {
     display: flex;
     flex-direction: column;
@@ -551,6 +672,27 @@
     padding: 2rem 1rem;
     color: #6b7280;
     font-weight: 500;
+}
+
+@media (max-width: 767.98px) {
+    .table-card-filters {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.85rem;
+    }
+
+    .table-card-filter-group {
+        width: 100%;
+    }
+
+    .table-card-filter-group .form-select {
+        width: 100%;
+    }
+
+    .table-card-filter-reset {
+        align-self: flex-end;
+        margin-left: 0;
+    }
 }
 
 @media (max-width: 575.98px) {

--- a/public/css/booking-wizard.css
+++ b/public/css/booking-wizard.css
@@ -234,17 +234,47 @@
     box-shadow: 0 20px 48px rgba(15, 23, 42, 0.08);
 }
 
+
 .table-card-filters {
+    display: grid;
+    grid-template-columns: minmax(0, 260px) minmax(0, 1fr);
+    gap: 1.4rem 1.8rem;
+    align-items: stretch;
+    margin-bottom: 1.5rem;
+    padding: 1.15rem 1.5rem;
+    background: linear-gradient(160deg, rgba(244, 247, 255, 0.92), rgba(255, 255, 255, 0.97));
+    border: 1px solid rgba(210, 218, 235, 0.75);
+    border-radius: 22px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), 0 16px 36px rgba(15, 23, 42, 0.08);
+}
+
+.table-card-filter-legend {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.4rem;
+    padding-right: 0.4rem;
+}
+
+.table-card-filter-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #0b1c3f;
+    letter-spacing: 0.01em;
+}
+
+.table-card-filter-caption {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(28, 42, 68, 0.75);
+    line-height: 1.4;
+}
+
+.table-card-filter-controls {
     display: flex;
     flex-wrap: wrap;
     align-items: flex-end;
-    gap: 1rem;
-    margin-bottom: 1.25rem;
-    padding: 0.75rem 1rem;
-    background: linear-gradient(145deg, rgba(244, 246, 252, 0.85), rgba(255, 255, 255, 0.92));
-    border: 1px solid rgba(217, 223, 238, 0.6);
-    border-radius: 18px;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 12px 28px rgba(15, 23, 42, 0.05);
+    gap: 1.05rem 1.35rem;
 }
 
 .table-card-filter-group {
@@ -331,24 +361,81 @@
     box-shadow: 0 0 0 0.35rem rgba(10, 132, 255, 0.22);
 }
 
+.table-card-filter-reset {
+    margin-left: auto;
+}
+
 .table-card-filter-reset .btn {
-    color: var(--wizard-primary);
+    color: #0066cc;
     font-weight: 600;
     letter-spacing: 0.01em;
     border-radius: 999px;
-    padding: 0.15rem 0.5rem;
-    transition: color 0.2s ease;
+    padding: 0.2rem 0.75rem;
+    transition: color 0.2s ease, background-color 0.2s ease;
 }
 
 .table-card-filter-reset .btn:hover,
 .table-card-filter-reset .btn:focus {
-    color: rgba(0, 102, 204, 0.95);
+    color: #004a99;
     text-decoration: none;
+    background-color: rgba(0, 102, 204, 0.1);
 }
 
 .table-card-filter-reset .btn:focus-visible {
     outline: none;
     box-shadow: 0 0 0 0.35rem rgba(10, 132, 255, 0.18);
+}
+
+.table-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.table-card-empty-state {
+    display: flex;
+    align-items: center;
+    gap: 1.4rem;
+    padding: 1.6rem 1.75rem;
+    border-radius: 20px;
+    border: 1px dashed rgba(160, 174, 206, 0.6);
+    background: rgba(248, 250, 255, 0.75);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.table-card-empty-visual {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 16px;
+    background: linear-gradient(145deg, rgba(99, 102, 241, 0.18), rgba(59, 130, 246, 0.28));
+    position: relative;
+}
+
+.table-card-empty-visual::before,
+.table-card-empty-visual::after {
+    content: '';
+    position: absolute;
+    inset: 0.5rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.7);
+}
+
+.table-card-empty-visual::after {
+    inset: 0.95rem;
+    background: rgba(10, 132, 255, 0.35);
+}
+
+.table-card-empty-copy h5 {
+    margin-bottom: 0.35rem;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #0b1c3f;
+    letter-spacing: 0.01em;
+}
+
+.table-card-empty-copy p {
+    color: rgba(28, 42, 68, 0.75);
+    font-size: 0.88rem;
 }
 
 .table-card .table {
@@ -674,11 +761,25 @@
     font-weight: 500;
 }
 
-@media (max-width: 767.98px) {
+@media (max-width: 991.98px) {
     .table-card-filters {
+        grid-template-columns: 1fr;
+        padding: 1.05rem 1.25rem;
+    }
+
+    .table-card-filter-legend {
+        padding-right: 0;
+    }
+
+    .table-card-filter-controls {
+        justify-content: flex-start;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .table-card-filter-controls {
         flex-direction: column;
         align-items: stretch;
-        gap: 0.85rem;
     }
 
     .table-card-filter-group {
@@ -690,8 +791,19 @@
     }
 
     .table-card-filter-reset {
-        align-self: flex-end;
         margin-left: 0;
+        width: 100%;
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .table-card-filter-reset .btn {
+        width: auto;
+    }
+
+    .table-card-empty-state {
+        flex-direction: column;
+        align-items: flex-start;
     }
 }
 

--- a/public/js/booking-wizard.js
+++ b/public/js/booking-wizard.js
@@ -31,6 +31,9 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
+        const ACTION_DUPLICATE_PER_STORE = 'duplicate_per_store';
+        const ACTION_DUPLICATE_SELECTED_STORES = 'duplicate_selected_stores';
+
         const form = document.querySelector('.booking-wizard-form');
         const steps = Array.from(document.querySelectorAll('.booking-step'));
         const stepperSteps = Array.from(document.querySelectorAll('.booking-stepper-step'));
@@ -64,6 +67,9 @@
         const brochureActionSelect = document.getElementById('brochure-action-select');
         const brochureActionButton = document.getElementById('brochure-action-submit');
         const brochureActionFeedback = document.getElementById('brochure-action-feedback');
+        const brochureSelectedStoresGroup = document.getElementById('brochure-action-stores-group');
+        const brochureSelectedStoresStatus = document.getElementById('brochure-action-stores-status');
+        const $brochureSelectedStoresSelect = $('#brochure-action-selected-stores');
         const bookingsSubtitle = document.getElementById('booking-results-subtitle');
         const bookingsLoading = document.getElementById('booking-results-loading');
         const bookingsError = document.getElementById('booking-results-error');
@@ -85,6 +91,11 @@
         let lastLoadedBrochures = null;
 
         const selectedBrochureIds = new Set();
+
+        let selectedStoresSelectInitialized = false;
+        const storeOptionsCache = new Map();
+        let storesAbortController = null;
+        let lastLoadedStoresCompanyId = null;
 
         if (brochuresSelectionInput && typeof brochuresSelectionInput.value === 'string') {
             brochuresSelectionInput.value
@@ -350,6 +361,11 @@
             selectedBrochureIds.clear();
             updateBrochureSelectionSummary();
             clearBrochureActionFeedback();
+            resetSelectedStoreSelector({
+                clearSelection: true,
+                clearOptions: resetLabel,
+                clearStatus: resetLabel,
+            });
 
             if (brochuresAbortController) {
                 brochuresAbortController.abort();
@@ -371,6 +387,8 @@
                 lastLoadedBrochuresOwnerId = null;
                 lastLoadedBrochures = null;
             }
+
+            updateSelectedStoresVisibility();
         }
 
         function showBrochuresLoading(companyLabel) {
@@ -461,6 +479,331 @@
             }
 
             showBrochureActionFeedback('success', parts.join(' '), nodes);
+        }
+
+        function setStoreStatus(message, tone = 'muted') {
+            if (!brochureSelectedStoresStatus) {
+                return;
+            }
+
+            const statusMessage = typeof message === 'string' && message.trim() !== ''
+                ? message.trim()
+                : '';
+
+            brochureSelectedStoresStatus.textContent = statusMessage;
+
+            const isDanger = tone === 'danger';
+            const isSuccess = tone === 'success';
+
+            brochureSelectedStoresStatus.classList.toggle('text-danger', isDanger);
+            brochureSelectedStoresStatus.classList.toggle('text-success', isSuccess);
+            brochureSelectedStoresStatus.classList.toggle('text-muted', !isDanger && !isSuccess);
+        }
+
+        function ensureSelectedStoresSelect2() {
+            if (!$brochureSelectedStoresSelect || $brochureSelectedStoresSelect.length === 0) {
+                return;
+            }
+
+            if (selectedStoresSelectInitialized) {
+                return;
+            }
+
+            const dropdownParent = brochureSelectedStoresGroup
+                ? $(brochureSelectedStoresGroup)
+                : $(document.body);
+
+            $brochureSelectedStoresSelect.select2({
+                placeholder: $brochureSelectedStoresSelect.data('placeholder') || 'Select stores',
+                allowClear: true,
+                tags: true,
+                width: '100%',
+                tokenSeparators: [',', ' '],
+                dropdownParent,
+            });
+
+            selectedStoresSelectInitialized = true;
+        }
+
+        function normalizeStoreOption(store) {
+            if (!store || typeof store !== 'object') {
+                return null;
+            }
+
+            let identifier = '';
+
+            if (typeof store.id === 'string' && store.id.trim() !== '') {
+                identifier = store.id.trim();
+            } else if (typeof store.storeNumber === 'string' && store.storeNumber.trim() !== '') {
+                identifier = store.storeNumber.trim();
+            }
+
+            if (identifier === '') {
+                return null;
+            }
+
+            const name = typeof store.name === 'string' ? store.name.trim() : '';
+            const label = typeof store.label === 'string' && store.label.trim() !== ''
+                ? store.label.trim()
+                : name !== ''
+                    ? `${identifier} — ${name}`
+                    : identifier;
+
+            return {
+                id: identifier,
+                text: label,
+                name,
+            };
+        }
+
+        function populateStoreOptions(companyId, stores) {
+            if (!$brochureSelectedStoresSelect || $brochureSelectedStoresSelect.length === 0) {
+                return 0;
+            }
+
+            const normalizedStores = Array.isArray(stores)
+                ? stores
+                    .map((store) => normalizeStoreOption(store))
+                    .filter((store) => store !== null)
+                : [];
+
+            storeOptionsCache.set(companyId, normalizedStores);
+
+            const currentValues = $brochureSelectedStoresSelect.val();
+            const selectedValues = Array.isArray(currentValues)
+                ? currentValues
+                    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+                    .filter((value) => value !== '')
+                : [];
+            const uniqueSelectedValues = Array.from(new Set(selectedValues));
+
+            const customSelections = [];
+
+            $brochureSelectedStoresSelect.find('option').each((_, option) => {
+                const value = option.value;
+                if (!value || uniqueSelectedValues.indexOf(value) === -1) {
+                    return;
+                }
+
+                const stillPresent = normalizedStores.some((store) => store && store.id === value);
+                if (!stillPresent) {
+                    customSelections.push({
+                        id: value,
+                        text: option.textContent || value,
+                    });
+                }
+            });
+
+            $brochureSelectedStoresSelect.empty();
+
+            normalizedStores.forEach((store) => {
+                if (!store) {
+                    return;
+                }
+
+                const option = new Option(store.text, store.id, false, uniqueSelectedValues.indexOf(store.id) !== -1);
+                if (store.name) {
+                    option.dataset.storeName = store.name;
+                }
+
+                $brochureSelectedStoresSelect.append(option);
+            });
+
+            customSelections.forEach((store) => {
+                const option = new Option(store.text, store.id, false, true);
+                option.dataset.custom = '1';
+                $brochureSelectedStoresSelect.append(option);
+            });
+
+            $brochureSelectedStoresSelect.trigger('change');
+
+            return normalizedStores.length;
+        }
+
+        function loadStoresForCompany(companyId) {
+            if (!companyId || !$brochureSelectedStoresSelect || $brochureSelectedStoresSelect.length === 0) {
+                return;
+            }
+
+            ensureSelectedStoresSelect2();
+
+            const normalizedCompanyId = String(companyId).trim();
+            if (normalizedCompanyId === '') {
+                return;
+            }
+
+            if (storesAbortController) {
+                storesAbortController.abort();
+            }
+
+            const cached = storeOptionsCache.get(normalizedCompanyId);
+            if (cached) {
+                const count = populateStoreOptions(normalizedCompanyId, cached);
+                const hasStores = count > 0;
+                $brochureSelectedStoresSelect.prop('disabled', !hasStores);
+                setStoreStatus(
+                    hasStores
+                        ? 'Select one or more stores to duplicate into.'
+                        : 'No stores found for the selected company.',
+                    hasStores ? 'muted' : 'danger'
+                );
+                lastLoadedStoresCompanyId = normalizedCompanyId;
+                return;
+            }
+
+            const controller = new AbortController();
+            storesAbortController = controller;
+            lastLoadedStoresCompanyId = normalizedCompanyId;
+            setStoreStatus('Loading stores...', 'muted');
+            $brochureSelectedStoresSelect.prop('disabled', true);
+
+            fetchJson(`/booking-wizard/api/stores?companyId=${encodeURIComponent(normalizedCompanyId)}`, {
+                signal: controller.signal,
+            })
+                .then((stores) => {
+                    if (storesAbortController !== controller) {
+                        return;
+                    }
+
+                    const count = populateStoreOptions(normalizedCompanyId, Array.isArray(stores) ? stores : []);
+                    const hasStores = count > 0;
+                    $brochureSelectedStoresSelect.prop('disabled', !hasStores);
+                    setStoreStatus(
+                        hasStores
+                            ? 'Select one or more stores to duplicate into.'
+                            : 'No stores found for the selected company.',
+                        hasStores ? 'muted' : 'danger'
+                    );
+                })
+                .catch((error) => {
+                    if (error && error.name === 'AbortError') {
+                        return;
+                    }
+
+                    if (storesAbortController !== controller) {
+                        return;
+                    }
+
+                    $brochureSelectedStoresSelect.prop('disabled', false);
+                    setStoreStatus(error && error.message ? error.message : 'Unable to load stores.', 'danger');
+                })
+                .finally(() => {
+                    if (storesAbortController === controller) {
+                        storesAbortController = null;
+                    }
+                });
+        }
+
+        function resetSelectedStoreSelector(options = {}) {
+            const {
+                clearSelection = false,
+                clearOptions = false,
+                clearStatus = false,
+                disable = true,
+            } = options || {};
+
+            if (storesAbortController) {
+                storesAbortController.abort();
+                storesAbortController = null;
+            }
+
+            if ($brochureSelectedStoresSelect && $brochureSelectedStoresSelect.length) {
+                if (clearOptions) {
+                    $brochureSelectedStoresSelect.find('option').remove();
+                }
+
+                if (clearSelection) {
+                    $brochureSelectedStoresSelect.val(null).trigger('change');
+                }
+
+                if (disable) {
+                    $brochureSelectedStoresSelect.prop('disabled', true);
+                }
+            }
+
+            if (clearOptions) {
+                lastLoadedStoresCompanyId = null;
+            }
+
+            if (clearStatus) {
+                setStoreStatus('Choose a company to load store suggestions.', 'muted');
+            }
+        }
+
+        function getSelectedStoreValues() {
+            if (!$brochureSelectedStoresSelect || $brochureSelectedStoresSelect.length === 0) {
+                return [];
+            }
+
+            const values = $brochureSelectedStoresSelect.val();
+
+            if (!Array.isArray(values)) {
+                return [];
+            }
+
+            const normalized = values
+                .map((value) => {
+                    if (typeof value !== 'string') {
+                        return '';
+                    }
+
+                    const trimmed = value.trim();
+                    return trimmed;
+                })
+                .filter((value) => value !== '');
+
+            return Array.from(new Set(normalized));
+        }
+
+        function getCurrentBrochureAction() {
+            if (!brochureActionSelect) {
+                return ACTION_DUPLICATE_PER_STORE;
+            }
+
+            const value = typeof brochureActionSelect.value === 'string'
+                ? brochureActionSelect.value.trim()
+                : '';
+
+            return value === '' ? ACTION_DUPLICATE_PER_STORE : value;
+        }
+
+        function updateSelectedStoresVisibility() {
+            if (!brochureSelectedStoresGroup) {
+                return;
+            }
+
+            const currentAction = getCurrentBrochureAction();
+            const requiresStores = currentAction === ACTION_DUPLICATE_SELECTED_STORES;
+
+            brochureSelectedStoresGroup.classList.toggle('d-none', !requiresStores);
+
+            if (!requiresStores) {
+                resetSelectedStoreSelector({ clearSelection: false, disable: true });
+                return;
+            }
+
+            ensureSelectedStoresSelect2();
+
+            const companyValue = companySelect ? companySelect.value : '';
+            const normalizedCompany = typeof companyValue === 'string' ? companyValue.trim() : '';
+
+            if (normalizedCompany === '') {
+                resetSelectedStoreSelector({
+                    clearSelection: true,
+                    clearOptions: false,
+                    clearStatus: true,
+                });
+                return;
+            }
+
+            if (lastLoadedStoresCompanyId !== normalizedCompany) {
+                resetSelectedStoreSelector({
+                    clearSelection: true,
+                    clearOptions: true,
+                });
+            }
+
+            loadStoresForCompany(normalizedCompany);
         }
 
         function hideBookingsMessages() {
@@ -1473,6 +1816,12 @@
             });
         });
 
+        if (brochureActionSelect) {
+            brochureActionSelect.addEventListener('change', () => {
+                updateSelectedStoresVisibility();
+            });
+        }
+
         if (brochureActionButton) {
             brochureActionButton.addEventListener('click', () => {
                 clearBrochureActionFeedback();
@@ -1500,8 +1849,7 @@
                     return;
                 }
 
-                const actionValue = brochureActionSelect ? brochureActionSelect.value : 'duplicate_per_store';
-                const normalizedAction = typeof actionValue === 'string' ? actionValue.trim() : '';
+                const normalizedAction = getCurrentBrochureAction();
 
                 if (normalizedAction === '') {
                     showBrochureActionFeedback('warning', 'Choose an action before continuing.');
@@ -1514,6 +1862,35 @@
                     ownerId: ownerSelect.value,
                     brochureIds: Array.from(selectedBrochureIds),
                 };
+
+                if (normalizedAction === ACTION_DUPLICATE_SELECTED_STORES) {
+                    if (storesAbortController) {
+                        showBrochureActionFeedback('info', 'Please wait for the store list to finish loading.');
+                        return;
+                    }
+
+                    ensureSelectedStoresSelect2();
+
+                    if ($brochureSelectedStoresSelect && $brochureSelectedStoresSelect.prop('disabled')) {
+                        const statusMessage = brochureSelectedStoresStatus && brochureSelectedStoresStatus.textContent
+                            ? brochureSelectedStoresStatus.textContent
+                            : 'Stores are unavailable for the selected company.';
+                        showBrochureActionFeedback('warning', statusMessage);
+                        return;
+                    }
+
+                    const selectedStores = getSelectedStoreValues();
+
+                    if (selectedStores.length === 0) {
+                        showBrochureActionFeedback('warning', 'Select at least one store to duplicate brochures.');
+                        if (brochureSelectedStoresGroup) {
+                            brochureSelectedStoresGroup.classList.remove('d-none');
+                        }
+                        return;
+                    }
+
+                    payload.stores = selectedStores;
+                }
 
                 const originalText = brochureActionButton.textContent;
                 brochureActionButton.disabled = true;
@@ -1565,6 +1942,7 @@
             }
         });
 
+        updateSelectedStoresVisibility();
         showStep(0);
     });
 })();

--- a/public/js/booking-wizard.js
+++ b/public/js/booking-wizard.js
@@ -67,6 +67,9 @@
         const brochureActionSelect = document.getElementById('brochure-action-select');
         const brochureActionButton = document.getElementById('brochure-action-submit');
         const brochureActionFeedback = document.getElementById('brochure-action-feedback');
+        const brochureFilterDeleted = document.getElementById('brochure-filter-deleted');
+        const brochureFilterTimeInputs = Array.from(document.querySelectorAll('input[name="brochure-filter-time"]'));
+        const brochureFilterResetButton = document.getElementById('brochure-filter-reset');
         const brochureSelectedStoresGroup = document.getElementById('brochure-action-stores-group');
         const brochureSelectedStoresStatus = document.getElementById('brochure-action-stores-status');
         const $brochureSelectedStoresSelect = $('#brochure-action-selected-stores');
@@ -89,8 +92,11 @@
         let lastLoadedBrochuresCompanyId = null;
         let lastLoadedBrochuresOwnerId = null;
         let lastLoadedBrochures = null;
+        let lastLoadedBrochuresFiltersKey = null;
 
         const selectedBrochureIds = new Set();
+
+        let defaultBrochureFilterState = null;
 
         let selectedStoresSelectInitialized = false;
         const storeOptionsCache = new Map();
@@ -108,6 +114,8 @@
         }
 
         updateBrochureSelectionSummary();
+
+        defaultBrochureFilterState = cloneBrochureFilters(getNormalizedBrochureFilters());
 
         let bookingsAbortController = null;
         let lastLoadedBookingsCompanyId = null;
@@ -261,6 +269,122 @@
                 : `${count} brochures selected`;
         }
 
+        function cloneBrochureFilters(filters) {
+            if (!filters || typeof filters !== 'object') {
+                return {
+                    deleted: 'active',
+                    timeConstraints: [],
+                };
+            }
+
+            const deleted = typeof filters.deleted === 'string'
+                ? filters.deleted.trim().toLowerCase()
+                : 'active';
+
+            const normalized = {
+                deleted: deleted === 'deleted' ? 'deleted' : 'active',
+                timeConstraints: [],
+            };
+
+            const source = Array.isArray(filters.timeConstraints) ? filters.timeConstraints : [];
+
+            source.forEach((value) => {
+                let normalizedValue = '';
+
+                if (typeof value === 'string') {
+                    normalizedValue = value.trim().toLowerCase();
+                } else if (value !== null && value !== undefined) {
+                    normalizedValue = String(value).trim().toLowerCase();
+                }
+
+                if (normalizedValue === '' || normalized.timeConstraints.includes(normalizedValue)) {
+                    return;
+                }
+
+                normalized.timeConstraints.push(normalizedValue);
+            });
+
+            return normalized;
+        }
+
+        function getBrochureFiltersKey(filters) {
+            const snapshot = cloneBrochureFilters(filters);
+            const sortedConstraints = snapshot.timeConstraints.slice().sort();
+
+            return JSON.stringify({
+                deleted: snapshot.deleted,
+                timeConstraints: sortedConstraints,
+            });
+        }
+
+        function getNormalizedBrochureFilters() {
+            const selectedConstraints = [];
+
+            brochureFilterTimeInputs.forEach((input) => {
+                if (!(input instanceof HTMLInputElement) || !input.checked) {
+                    return;
+                }
+
+                const value = typeof input.value === 'string'
+                    ? input.value.trim().toLowerCase()
+                    : '';
+
+                if (value !== '' && !selectedConstraints.includes(value)) {
+                    selectedConstraints.push(value);
+                }
+            });
+
+            const deletedValue = brochureFilterDeleted && typeof brochureFilterDeleted.value === 'string'
+                ? brochureFilterDeleted.value.trim().toLowerCase()
+                : 'active';
+
+            return cloneBrochureFilters({
+                deleted: deletedValue,
+                timeConstraints: selectedConstraints,
+            });
+        }
+
+        function resetBrochureFilterControls() {
+            const defaults = defaultBrochureFilterState || {
+                deleted: 'active',
+                timeConstraints: ['current', 'upcoming'],
+            };
+
+            if (brochureFilterDeleted) {
+                brochureFilterDeleted.value = defaults.deleted;
+            }
+
+            brochureFilterTimeInputs.forEach((input) => {
+                if (!(input instanceof HTMLInputElement)) {
+                    return;
+                }
+
+                const value = typeof input.value === 'string'
+                    ? input.value.trim().toLowerCase()
+                    : '';
+
+                input.checked = defaults.timeConstraints.includes(value);
+            });
+        }
+
+        function handleBrochureFiltersChanged() {
+            const hasOwner = !!ownerSelect.value;
+            const hasCompany = !!companySelect.value;
+
+            if (!hasOwner || !hasCompany) {
+                return;
+            }
+
+            const filters = getNormalizedBrochureFilters();
+            const selectedText = $companySelect.find('option:selected').text().trim();
+
+            if (currentStep === 2) {
+                loadBrochures(companySelect.value, selectedText, ownerSelect.value, filters);
+            } else {
+                lastLoadedBrochuresFiltersKey = null;
+            }
+        }
+
         function clearBrochureActionFeedback() {
             if (!brochureActionFeedback) {
                 return;
@@ -386,6 +510,7 @@
                 lastLoadedBrochuresCompanyId = null;
                 lastLoadedBrochuresOwnerId = null;
                 lastLoadedBrochures = null;
+                lastLoadedBrochuresFiltersKey = null;
             }
 
             updateSelectedStoresVisibility();
@@ -1480,7 +1605,7 @@
             brochuresTableWrapper.classList.remove('d-none');
         }
 
-        function loadBrochures(companyId, companyLabel, ownerId) {
+        function loadBrochures(companyId, companyLabel, ownerId, filters) {
             const normalizedCompanyId = typeof companyId === 'string' ? companyId.trim() : String(companyId);
             if (!normalizedCompanyId) {
                 return;
@@ -1488,6 +1613,9 @@
 
             const normalizedOwnerId = typeof ownerId === 'string' ? ownerId.trim() : ownerId;
             const ownerKey = normalizedOwnerId && normalizedOwnerId !== '' ? normalizedOwnerId : null;
+
+            const filterSnapshot = cloneBrochureFilters(filters || getNormalizedBrochureFilters());
+            const filtersKey = getBrochureFiltersKey(filterSnapshot);
 
             if (brochuresAbortController) {
                 brochuresAbortController.abort();
@@ -1499,6 +1627,7 @@
             if (
                 lastLoadedBrochuresCompanyId === normalizedCompanyId &&
                 lastLoadedBrochuresOwnerId === ownerKey &&
+                lastLoadedBrochuresFiltersKey === filtersKey &&
                 Array.isArray(lastLoadedBrochures)
             ) {
                 setStepLabel(2, stepLabel);
@@ -1512,13 +1641,28 @@
             lastLoadedBrochuresCompanyId = normalizedCompanyId;
             lastLoadedBrochuresOwnerId = ownerKey;
             lastLoadedBrochures = null;
+            lastLoadedBrochuresFiltersKey = null;
 
             setStepLabel(2, stepLabel);
             showBrochuresLoading(companyLabel);
 
             const params = new URLSearchParams({ companyId: normalizedCompanyId });
-            if (ownerKey) {
+            if (ownerKey !== null) {
                 params.append('ownerId', ownerKey);
+            }
+
+            params.append('deletedFilter', filterSnapshot.deleted === 'deleted' ? 'deleted' : 'active');
+
+            if (Array.isArray(filterSnapshot.timeConstraints) && filterSnapshot.timeConstraints.length > 0) {
+                filterSnapshot.timeConstraints
+                    .slice()
+                    .forEach((constraint) => {
+                        if (typeof constraint !== 'string' || constraint.trim() === '') {
+                            return;
+                        }
+
+                        params.append(`timeConstraint[${constraint}]`, 'true');
+                    });
             }
 
             fetchJson(`/booking-wizard/api/brochures?${params.toString()}`, {
@@ -1530,6 +1674,7 @@
                     }
 
                     lastLoadedBrochures = Array.isArray(brochures) ? brochures : [];
+                    lastLoadedBrochuresFiltersKey = filtersKey;
                     renderBrochures(lastLoadedBrochures, companyLabel);
                 })
                 .catch((error) => {
@@ -1544,6 +1689,7 @@
                     lastLoadedBrochuresCompanyId = null;
                     lastLoadedBrochuresOwnerId = null;
                     lastLoadedBrochures = null;
+                    lastLoadedBrochuresFiltersKey = null;
                     showBrochuresError(error && error.message ? error.message : 'Unable to load brochures.', companyLabel);
                 })
                 .finally(() => {
@@ -1782,7 +1928,12 @@
                     showStep(step);
 
                     if (step === 2) {
-                        loadBrochures(companySelect.value, selectedText, ownerSelect.value);
+                        loadBrochures(
+                            companySelect.value,
+                            selectedText,
+                            ownerSelect.value,
+                            getNormalizedBrochureFilters(),
+                        );
                     } else if (step >= 3) {
                         loadBookings(companySelect.value, selectedText, ownerSelect.value);
                     }
@@ -1815,6 +1966,40 @@
                 showStep(step);
             });
         });
+
+        if (brochureFilterDeleted) {
+            brochureFilterDeleted.addEventListener('change', () => {
+                handleBrochureFiltersChanged();
+            });
+        }
+
+        brochureFilterTimeInputs.forEach((input) => {
+            if (!(input instanceof HTMLInputElement)) {
+                return;
+            }
+
+            input.addEventListener('change', () => {
+                if (!input.checked) {
+                    const anyChecked = brochureFilterTimeInputs.some(
+                        (timeInput) => timeInput instanceof HTMLInputElement && timeInput.checked,
+                    );
+
+                    if (!anyChecked) {
+                        input.checked = true;
+                        return;
+                    }
+                }
+
+                handleBrochureFiltersChanged();
+            });
+        });
+
+        if (brochureFilterResetButton) {
+            brochureFilterResetButton.addEventListener('click', () => {
+                resetBrochureFilterControls();
+                handleBrochureFiltersChanged();
+            });
+        }
 
         if (brochureActionSelect) {
             brochureActionSelect.addEventListener('change', () => {

--- a/public/js/booking-wizard.js
+++ b/public/js/booking-wizard.js
@@ -57,6 +57,7 @@
         const brochuresError = document.getElementById('brochure-results-error');
         const brochuresEmpty = document.getElementById('brochure-results-empty');
         const brochuresTableWrapper = document.getElementById('brochure-results-table-wrapper');
+        const brochuresTableContainer = document.getElementById('brochure-results-table-container');
         const brochuresTableBody = document.querySelector('#brochure-results-table tbody');
         const brochuresSearchInput = document.getElementById('brochure-results-search');
         const brochuresPageSizeSelect = document.getElementById('brochure-results-page-size');
@@ -70,6 +71,7 @@
         const brochureFilterDeleted = document.getElementById('brochure-filter-deleted');
         const brochureFilterTimeInputs = Array.from(document.querySelectorAll('input[name="brochure-filter-time"]'));
         const brochureFilterResetButton = document.getElementById('brochure-filter-reset');
+        const brochureEmptyResetButton = document.getElementById('brochure-empty-reset');
         const brochureSelectedStoresGroup = document.getElementById('brochure-action-stores-group');
         const brochureSelectedStoresStatus = document.getElementById('brochure-action-stores-status');
         const $brochureSelectedStoresSelect = $('#brochure-action-selected-stores');
@@ -125,7 +127,7 @@
         let currentStep = 0;
 
         brochuresTableManager = createTableManager({
-            wrapper: brochuresTableWrapper,
+            wrapper: brochuresTableContainer,
             tableBody: brochuresTableBody,
             searchInput: brochuresSearchInput,
             pageSizeSelect: brochuresPageSizeSelect,
@@ -501,7 +503,13 @@
 
             if (brochuresTableManager) {
                 brochuresTableManager.reset();
-            } else if (brochuresTableWrapper) {
+            }
+
+            if (brochuresTableContainer) {
+                brochuresTableContainer.classList.add('d-none');
+            }
+
+            if (brochuresTableWrapper) {
                 brochuresTableWrapper.classList.add('d-none');
             }
 
@@ -523,8 +531,14 @@
 
             if (brochuresTableManager) {
                 brochuresTableManager.reset();
-            } else if (brochuresTableWrapper) {
-                brochuresTableWrapper.classList.add('d-none');
+            }
+
+            if (brochuresTableContainer) {
+                brochuresTableContainer.classList.add('d-none');
+            }
+
+            if (brochuresTableWrapper) {
+                brochuresTableWrapper.classList.remove('d-none');
             }
 
             if (brochuresLoading) {
@@ -538,8 +552,14 @@
 
             if (brochuresTableManager) {
                 brochuresTableManager.reset();
-            } else if (brochuresTableWrapper) {
-                brochuresTableWrapper.classList.add('d-none');
+            }
+
+            if (brochuresTableContainer) {
+                brochuresTableContainer.classList.add('d-none');
+            }
+
+            if (brochuresTableWrapper) {
+                brochuresTableWrapper.classList.remove('d-none');
             }
 
             if (brochuresError) {
@@ -1588,14 +1608,27 @@
             pruneSelectedBrochureIds(items);
             updateBrochureSelectionSummary();
 
+            brochuresTableWrapper.classList.remove('d-none');
+
             if (items.length === 0) {
                 if (brochuresTableManager) {
                     brochuresTableManager.reset();
+                }
+                if (brochuresTableContainer) {
+                    brochuresTableContainer.classList.add('d-none');
                 }
                 if (brochuresEmpty) {
                     brochuresEmpty.classList.remove('d-none');
                 }
                 return;
+            }
+
+            if (brochuresEmpty) {
+                brochuresEmpty.classList.add('d-none');
+            }
+
+            if (brochuresTableContainer) {
+                brochuresTableContainer.classList.remove('d-none');
             }
 
             if (brochuresTableManager) {
@@ -1996,6 +2029,13 @@
 
         if (brochureFilterResetButton) {
             brochureFilterResetButton.addEventListener('click', () => {
+                resetBrochureFilterControls();
+                handleBrochureFiltersChanged();
+            });
+        }
+
+        if (brochureEmptyResetButton) {
+            brochureEmptyResetButton.addEventListener('click', () => {
                 resetBrochureFilterControls();
                 handleBrochureFiltersChanged();
             });

--- a/src/Controller/BookingWizardController.php
+++ b/src/Controller/BookingWizardController.php
@@ -43,8 +43,10 @@ class BookingWizardController extends AbstractController
             return $this->json(['error' => 'Missing or invalid ownerId or companyId parameter.'], Response::HTTP_BAD_REQUEST);
         }
 
+        $filters = $this->resolveBrochureFilters($request);
+
         try {
-            $brochures = $iprotoService->getBrochuresByOwnerAndCompany($ownerId, $companyId);
+            $brochures = $iprotoService->getBrochuresByOwnerAndCompany($ownerId, $companyId, $filters);
 
             return $this->json($brochures);
         } catch (\InvalidArgumentException $exception) {
@@ -53,6 +55,7 @@ class BookingWizardController extends AbstractController
             $logger->error('Brochure API request failed.', [
                 'companyId' => $companyId,
                 'ownerId' => $ownerId,
+                'filters' => $filters,
                 'exception' => $exception,
             ]);
 
@@ -61,6 +64,7 @@ class BookingWizardController extends AbstractController
             $logger->error('Unexpected error while loading brochures.', [
                 'companyId' => $companyId,
                 'ownerId' => $ownerId,
+                'filters' => $filters,
                 'exception' => $exception,
             ]);
 
@@ -262,6 +266,102 @@ class BookingWizardController extends AbstractController
 
             return $this->json(['error' => 'Unable to load CPC bookings.'], Response::HTTP_BAD_GATEWAY);
         }
+    }
+
+    /**
+     * @return array{deletedFilter: string, timeConstraints: array<int, string>}
+     */
+    private function resolveBrochureFilters(Request $request): array
+    {
+        $filters = [
+            'deletedFilter' => 'active',
+            'timeConstraints' => ['current', 'upcoming'],
+        ];
+
+        $deletedFilterRaw = strtolower(trim((string) $request->query->get('deletedFilter', '')));
+        if ($deletedFilterRaw === 'deleted') {
+            $filters['deletedFilter'] = 'deleted';
+        } elseif ($deletedFilterRaw === 'all') {
+            $filters['deletedFilter'] = 'all';
+        } else {
+            $filters['deletedFilter'] = 'active';
+        }
+
+        $timeConstraintParam = $request->query->all('timeConstraint');
+        $timeConstraints = $this->normalizeTimeConstraintFilters($timeConstraintParam);
+
+        if (!empty($timeConstraints)) {
+            $filters['timeConstraints'] = $timeConstraints;
+        } elseif ($request->query->has('timeConstraint')) {
+            $filters['timeConstraints'] = [];
+        }
+
+        return $filters;
+    }
+
+    /**
+     * @param mixed $raw
+     * @return array<int, string>
+     */
+    private function normalizeTimeConstraintFilters(mixed $raw): array
+    {
+        $allowed = ['current', 'upcoming', 'past'];
+        $normalized = [];
+
+        if (is_array($raw)) {
+            foreach ($raw as $key => $value) {
+                if (is_int($key)) {
+                    $nested = $this->normalizeTimeConstraintFilters($value);
+                    foreach ($nested as $item) {
+                        if (!in_array($item, $normalized, true)) {
+                            $normalized[] = $item;
+                        }
+                    }
+                    continue;
+                }
+
+                if (!$this->isTruthy($value)) {
+                    continue;
+                }
+
+                $constraint = strtolower(trim((string) $key));
+                if ($constraint === '' || !in_array($constraint, $allowed, true) || in_array($constraint, $normalized, true)) {
+                    continue;
+                }
+
+                $normalized[] = $constraint;
+            }
+
+            return $normalized;
+        }
+
+        if (is_string($raw)) {
+            $constraint = strtolower(trim($raw));
+            if ($constraint !== '' && in_array($constraint, $allowed, true) && !in_array($constraint, $normalized, true)) {
+                $normalized[] = $constraint;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return $value !== 0;
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            return !in_array($normalized, ['', '0', 'false', 'off', 'no'], true);
+        }
+
+        return $value !== null;
     }
 
     private function normalizeStoreString(mixed $value): string

--- a/src/Controller/BookingWizardController.php
+++ b/src/Controller/BookingWizardController.php
@@ -68,6 +68,89 @@ class BookingWizardController extends AbstractController
         }
     }
 
+    #[Route('/booking-wizard/api/stores', name: 'app_booking_wizard_stores', methods: ['GET'])]
+    public function fetchStores(
+        Request $request,
+        IprotoService $iprotoService,
+        LoggerInterface $logger,
+    ): JsonResponse {
+        $companyId = trim((string) $request->query->get('companyId', ''));
+
+        if ($companyId === '') {
+            return $this->json(['error' => 'Missing or invalid companyId parameter.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $stores = $iprotoService->getStoresByCompany($companyId);
+            $formatted = [];
+
+            foreach ($stores as $store) {
+                if (!is_array($store)) {
+                    continue;
+                }
+
+                $storeNumber = $this->normalizeStoreString($store['storeNumber'] ?? $store['store_number'] ?? $store['number'] ?? null);
+
+                if ($storeNumber === '' || isset($formatted[$storeNumber])) {
+                    continue;
+                }
+
+                $name = $this->normalizeStoreString(
+                    $store['name'] ?? $store['storeName'] ?? $store['description'] ?? $store['title'] ?? null,
+                );
+                $city = $this->normalizeStoreString($store['city'] ?? $store['cityName'] ?? $store['locationCity'] ?? null);
+                $state = $this->normalizeStoreString($store['state'] ?? $store['region'] ?? $store['province'] ?? null);
+
+                $label = $storeNumber;
+
+                if ($name !== '' && $city !== '') {
+                    $label = sprintf('%s — %s (%s)', $storeNumber, $name, $city);
+                } elseif ($name !== '') {
+                    $label = sprintf('%s — %s', $storeNumber, $name);
+                } elseif ($city !== '') {
+                    $label = sprintf('%s — %s', $storeNumber, $city);
+                }
+
+                if ($state !== '') {
+                    if ($name !== '' && $city !== '') {
+                        $label = sprintf('%s — %s (%s, %s)', $storeNumber, $name, $city, $state);
+                    } elseif ($city !== '') {
+                        $label = sprintf('%s — %s (%s)', $storeNumber, $city, $state);
+                    } elseif ($name !== '') {
+                        $label = sprintf('%s — %s (%s)', $storeNumber, $name, $state);
+                    }
+                }
+
+                $formatted[$storeNumber] = [
+                    'id' => $storeNumber,
+                    'storeNumber' => $storeNumber,
+                    'label' => $label,
+                    'name' => $name,
+                    'city' => $city,
+                    'state' => $state,
+                ];
+            }
+
+            return $this->json(array_values($formatted));
+        } catch (\InvalidArgumentException $exception) {
+            return $this->json(['error' => $exception->getMessage()], Response::HTTP_BAD_REQUEST);
+        } catch (\RuntimeException $exception) {
+            $logger->error('Store API request failed.', [
+                'companyId' => $companyId,
+                'exception' => $exception,
+            ]);
+
+            return $this->json(['error' => $exception->getMessage()], Response::HTTP_BAD_GATEWAY);
+        } catch (\Throwable $exception) {
+            $logger->error('Unexpected error while loading stores.', [
+                'companyId' => $companyId,
+                'exception' => $exception,
+            ]);
+
+            return $this->json(['error' => 'Unable to load stores.'], Response::HTTP_BAD_GATEWAY);
+        }
+    }
+
     #[Route('/booking-wizard/api/brochure-actions', name: 'app_booking_wizard_brochure_actions', methods: ['POST'])]
     public function handleBrochureActions(
         Request $request,
@@ -84,17 +167,32 @@ class BookingWizardController extends AbstractController
         $companyId = trim((string) ($data['companyId'] ?? ''));
         $ownerId = trim((string) ($data['ownerId'] ?? ''));
         $brochureIds = $data['brochureIds'] ?? [];
+        $storeNumbers = $data['stores'] ?? ($data['selectedStores'] ?? []);
 
         if (!is_array($brochureIds)) {
             $brochureIds = [];
         }
 
-        if ($action !== BrochureActionService::ACTION_DUPLICATE_PER_STORE) {
-            return $this->json(['error' => 'Unsupported brochure action requested.'], Response::HTTP_BAD_REQUEST);
+        if (!is_array($storeNumbers)) {
+            $storeNumbers = [];
         }
 
         try {
-            $result = $brochureActionService->duplicateBrochuresPerStore($companyId, $ownerId, $brochureIds);
+            switch ($action) {
+                case BrochureActionService::ACTION_DUPLICATE_PER_STORE:
+                    $result = $brochureActionService->duplicateBrochuresPerStore($companyId, $ownerId, $brochureIds);
+                    break;
+                case BrochureActionService::ACTION_DUPLICATE_SELECTED_STORES:
+                    $result = $brochureActionService->duplicateBrochuresPerSelectedStores(
+                        $companyId,
+                        $ownerId,
+                        $brochureIds,
+                        $storeNumbers,
+                    );
+                    break;
+                default:
+                    return $this->json(['error' => 'Unsupported brochure action requested.'], Response::HTTP_BAD_REQUEST);
+            }
 
             return $this->json($result);
         } catch (\InvalidArgumentException $exception) {
@@ -164,5 +262,26 @@ class BookingWizardController extends AbstractController
 
             return $this->json(['error' => 'Unable to load CPC bookings.'], Response::HTTP_BAD_GATEWAY);
         }
+    }
+
+    private function normalizeStoreString(mixed $value): string
+    {
+        if (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        }
+
+        if (!is_string($value)) {
+            return '';
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return '';
+        }
+
+        $normalized = preg_replace('/\s+/', ' ', $trimmed);
+
+        return is_string($normalized) && $normalized !== '' ? $normalized : $trimmed;
     }
 }

--- a/src/Controller/BookingWizardController.php
+++ b/src/Controller/BookingWizardController.php
@@ -118,7 +118,12 @@ class BookingWizardController extends AbstractController
                 'exception' => $exception,
             ]);
 
-            return $this->json(['error' => 'Unable to process brochure action.'], Response::HTTP_BAD_GATEWAY);
+            $message = trim($exception->getMessage());
+            $error = $message !== ''
+                ? sprintf('Unable to process brochure action: %s', $message)
+                : 'Unable to process brochure action.';
+
+            return $this->json(['error' => $error], Response::HTTP_BAD_GATEWAY);
         }
     }
 

--- a/src/Dto/Product.php
+++ b/src/Dto/Product.php
@@ -1,0 +1,445 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+class Product extends AbstractDto
+{
+    private const INTEGRATION_URL = 'https://iproto.offerista.com/api/integrations/';
+
+    /**
+     * Headers used when exporting products to CSV.
+     */
+    public const CSV_HEADERS = [
+        'integration',
+        'productNumber',
+        'title',
+        'description',
+        'price',
+        'currency',
+        'secondaryPrice',
+        'secondaryCurrency',
+        'priceIsVariable',
+        'manufacturerPrice',
+        'secondaryManufacturerPrice',
+        'manufacturerNumber',
+        'gtin',
+        'languageCode',
+        'keywords',
+        'trackingPixels',
+        'url',
+        'brandText',
+        'brandImage',
+        'amount',
+        'size',
+        'color',
+        'unitType',
+        'subTitle',
+        'salesRegion',
+        'validFrom',
+        'validTo',
+        'visibleFrom',
+        'hidden',
+        'additionalProperties',
+        'shipping',
+        'variants',
+    ];
+
+    private string $integration = '';
+    private string $productNumber = '';
+    private string $title = '';
+    private string $description = '';
+    private string $price = '';
+    private string $currency = '';
+    private string $secondaryPrice = '';
+    private string $secondaryCurrency = '';
+    private string $priceIsVariable = '';
+    private string $manufacturerPrice = '';
+    private string $secondaryManufacturerPrice = '';
+    private string $manufacturerNumber = '';
+    private string $gtin = '';
+    private string $languageCode = '';
+    private string $keywords = '';
+    private string $trackingPixels = '';
+    private string $url = '';
+    private string $brandText = '';
+    private string $brandImage = '';
+    private string $amount = '';
+    private string $size = '';
+    private string $color = '';
+    private string $unitType = '';
+    private string $subTitle = '';
+    private string $salesRegion = '';
+    private string $validFrom = '';
+    private string $validTo = '';
+    private string $visibleFrom = '';
+    private string $hidden = '';
+    private string $additionalProperties = '';
+    private string $shipping = '';
+    private string $variants = '';
+
+    public function toArray(): array
+    {
+        return [
+            'integration' => $this->getIntegration(),
+            'productNumber' => $this->getProductNumber(),
+            'title' => $this->getTitle(),
+            'description' => $this->getDescription(),
+            'price' => $this->getPrice(),
+            'currency' => $this->getCurrency(),
+            'secondaryPrice' => $this->getSecondaryPrice(),
+            'secondaryCurrency' => $this->getSecondaryCurrency(),
+            'priceIsVariable' => $this->getPriceIsVariable(),
+            'manufacturerPrice' => $this->getManufacturerPrice(),
+            'secondaryManufacturerPrice' => $this->getSecondaryManufacturerPrice(),
+            'manufacturerNumber' => $this->getManufacturerNumber(),
+            'gtin' => $this->getGtin(),
+            'languageCode' => $this->getLanguageCode(),
+            'keywords' => $this->getKeywords(),
+            'trackingPixels' => $this->getTrackingPixels(),
+            'url' => $this->getUrl(),
+            'brandText' => $this->getBrandText(),
+            'brandImage' => $this->getBrandImage(),
+            'amount' => $this->getAmount(),
+            'size' => $this->getSize(),
+            'color' => $this->getColor(),
+            'unitType' => $this->getUnitType(),
+            'subTitle' => $this->getSubTitle(),
+            'salesRegion' => $this->getSalesRegion(),
+            'validFrom' => $this->getValidFrom(),
+            'validTo' => $this->getValidTo(),
+            'visibleFrom' => $this->getVisibleFrom(),
+            'hidden' => $this->getHidden(),
+            'additionalProperties' => $this->getAdditionalProperties(),
+            'shipping' => $this->getShipping(),
+            'variants' => $this->getVariants(),
+        ];
+    }
+
+    protected function setIntegration(string $integration): void
+    {
+        if (str_starts_with($integration, 'http')) {
+            $this->integration = $integration;
+
+            return;
+        }
+
+        $this->integration = self::INTEGRATION_URL . ltrim($integration, '/');
+    }
+
+    public function getIntegration(): string
+    {
+        return $this->integration;
+    }
+
+    protected function setProductNumber(string $productNumber): void
+    {
+        $this->productNumber = $productNumber;
+    }
+
+    public function getProductNumber(): string
+    {
+        return $this->productNumber;
+    }
+
+    protected function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    protected function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    protected function setPrice(string $price): void
+    {
+        $this->price = $price;
+    }
+
+    public function getPrice(): string
+    {
+        return $this->price;
+    }
+
+    protected function setCurrency(string $currency): void
+    {
+        $this->currency = $currency;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    protected function setSecondaryPrice(string $secondaryPrice): void
+    {
+        $this->secondaryPrice = $secondaryPrice;
+    }
+
+    public function getSecondaryPrice(): string
+    {
+        return $this->secondaryPrice;
+    }
+
+    protected function setSecondaryCurrency(string $secondaryCurrency): void
+    {
+        $this->secondaryCurrency = $secondaryCurrency;
+    }
+
+    public function getSecondaryCurrency(): string
+    {
+        return $this->secondaryCurrency;
+    }
+
+    protected function setPriceIsVariable(string $priceIsVariable): void
+    {
+        $this->priceIsVariable = $priceIsVariable;
+    }
+
+    public function getPriceIsVariable(): string
+    {
+        return $this->priceIsVariable;
+    }
+
+    protected function setManufacturerPrice(string $manufacturerPrice): void
+    {
+        $this->manufacturerPrice = $manufacturerPrice;
+    }
+
+    public function getManufacturerPrice(): string
+    {
+        return $this->manufacturerPrice;
+    }
+
+    protected function setSecondaryManufacturerPrice(string $secondaryManufacturerPrice): void
+    {
+        $this->secondaryManufacturerPrice = $secondaryManufacturerPrice;
+    }
+
+    public function getSecondaryManufacturerPrice(): string
+    {
+        return $this->secondaryManufacturerPrice;
+    }
+
+    protected function setManufacturerNumber(string $manufacturerNumber): void
+    {
+        $this->manufacturerNumber = $manufacturerNumber;
+    }
+
+    public function getManufacturerNumber(): string
+    {
+        return $this->manufacturerNumber;
+    }
+
+    protected function setGtin(string $gtin): void
+    {
+        $this->gtin = $gtin;
+    }
+
+    public function getGtin(): string
+    {
+        return $this->gtin;
+    }
+
+    protected function setLanguageCode(string $languageCode): void
+    {
+        $this->languageCode = $languageCode;
+    }
+
+    public function getLanguageCode(): string
+    {
+        return $this->languageCode;
+    }
+
+    protected function setKeywords(string $keywords): void
+    {
+        $this->keywords = $keywords;
+    }
+
+    public function getKeywords(): string
+    {
+        return $this->keywords;
+    }
+
+    protected function setTrackingPixels(string $trackingPixels): void
+    {
+        $this->trackingPixels = $trackingPixels;
+    }
+
+    public function getTrackingPixels(): string
+    {
+        return $this->trackingPixels;
+    }
+
+    protected function setUrl(string $url): void
+    {
+        $this->url = $url;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    protected function setBrandText(string $brandText): void
+    {
+        $this->brandText = $brandText;
+    }
+
+    public function getBrandText(): string
+    {
+        return $this->brandText;
+    }
+
+    protected function setBrandImage(string $brandImage): void
+    {
+        $this->brandImage = $brandImage;
+    }
+
+    public function getBrandImage(): string
+    {
+        return $this->brandImage;
+    }
+
+    protected function setAmount(string $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    protected function setSize(string $size): void
+    {
+        $this->size = $size;
+    }
+
+    public function getSize(): string
+    {
+        return $this->size;
+    }
+
+    protected function setColor(string $color): void
+    {
+        $this->color = $color;
+    }
+
+    public function getColor(): string
+    {
+        return $this->color;
+    }
+
+    protected function setUnitType(string $unitType): void
+    {
+        $this->unitType = $unitType;
+    }
+
+    public function getUnitType(): string
+    {
+        return $this->unitType;
+    }
+
+    protected function setSubTitle(string $subTitle): void
+    {
+        $this->subTitle = $subTitle;
+    }
+
+    public function getSubTitle(): string
+    {
+        return $this->subTitle;
+    }
+
+    protected function setSalesRegion(string $salesRegion): void
+    {
+        $this->salesRegion = $salesRegion;
+    }
+
+    public function getSalesRegion(): string
+    {
+        return $this->salesRegion;
+    }
+
+    protected function setValidFrom(string $validFrom): void
+    {
+        $this->validFrom = $validFrom;
+    }
+
+    public function getValidFrom(): string
+    {
+        return $this->validFrom;
+    }
+
+    protected function setValidTo(string $validTo): void
+    {
+        $this->validTo = $validTo;
+    }
+
+    public function getValidTo(): string
+    {
+        return $this->validTo;
+    }
+
+    protected function setVisibleFrom(string $visibleFrom): void
+    {
+        $this->visibleFrom = $visibleFrom;
+    }
+
+    public function getVisibleFrom(): string
+    {
+        return $this->visibleFrom;
+    }
+
+    protected function setHidden(string $hidden): void
+    {
+        $this->hidden = $hidden;
+    }
+
+    public function getHidden(): string
+    {
+        return $this->hidden;
+    }
+
+    protected function setAdditionalProperties(string $additionalProperties): void
+    {
+        $this->additionalProperties = $additionalProperties;
+    }
+
+    public function getAdditionalProperties(): string
+    {
+        return $this->additionalProperties;
+    }
+
+    protected function setShipping(string $shipping): void
+    {
+        $this->shipping = $shipping;
+    }
+
+    public function getShipping(): string
+    {
+        return $this->shipping;
+    }
+
+    protected function setVariants(string $variants): void
+    {
+        $this->variants = $variants;
+    }
+
+    public function getVariants(): string
+    {
+        return $this->variants;
+    }
+}

--- a/src/Service/BookingWizard/BrochureActionService.php
+++ b/src/Service/BookingWizard/BrochureActionService.php
@@ -332,17 +332,17 @@ class BrochureActionService
             return $normalized;
         }
 
-        if (isset($this->brochurePdfCache[$pageId])) {
-            return $this->brochurePdfCache[$pageId];
+        if (isset($this->brochurePdfCache[$brochureId])) {
+            return $this->brochurePdfCache[$brochureId];
         }
 
         $this->ensureBrochurePdfDirectory();
 
-        $fileName = sprintf('brochure_%s.pdf', $pageId);
+        $fileName = sprintf('brochure_%s.pdf', $brochureId);
         $destination = $this->brochurePdfDir . '/' . $fileName;
 
         try {
-            $localPath = $this->iprotoService->downloadBrochurePdf($pageId, $destination);
+            $localPath = $this->iprotoService->downloadBrochurePdf($pageId, $destination, $brochureId);
         } catch (\Throwable $exception) {
             throw new \RuntimeException(
                 sprintf('Failed to download brochure PDF %s for brochure %s.', $pageId, $brochureId),
@@ -361,7 +361,7 @@ class BrochureActionService
             );
         }
 
-        $this->brochurePdfCache[$pageId] = $uploadedUrl;
+        $this->brochurePdfCache[$brochureId] = $uploadedUrl;
 
         return $uploadedUrl;
     }

--- a/src/Service/BookingWizard/BrochureActionService.php
+++ b/src/Service/BookingWizard/BrochureActionService.php
@@ -74,7 +74,12 @@ class BrochureActionService
         }
 
         $brochureCsv = $this->csvService->createCsvFromBrochure($duplicatedBrochures, $normalizedCompanyId);
-        $import = $this->iprotoService->importData($brochureCsv);
+
+        try {
+            $import = $this->iprotoService->importData($brochureCsv);
+        } catch (\Throwable $exception) {
+            throw new \RuntimeException('Failed to import duplicated brochures.', 0, $exception);
+        }
 
         return [
             'summary' => [

--- a/src/Service/BookingWizard/BrochureActionService.php
+++ b/src/Service/BookingWizard/BrochureActionService.php
@@ -12,6 +12,7 @@ use InvalidArgumentException;
 class BrochureActionService
 {
     public const ACTION_DUPLICATE_PER_STORE = 'duplicate_per_store';
+    public const ACTION_DUPLICATE_SELECTED_STORES = 'duplicate_selected_stores';
 
     public function __construct(
         private IprotoService $iprotoService,
@@ -31,9 +32,42 @@ class BrochureActionService
      */
     public function duplicateBrochuresPerStore(string $companyId, string $ownerId, array $brochureIds): array
     {
+        return $this->duplicateBrochuresInternal($companyId, $ownerId, $brochureIds, null);
+    }
+
+    /**
+     * @param array<int, int|string> $brochureIds
+     * @param array<int, int|string> $storeNumbers
+     *
+     * @return array{
+     *     summary: array{selectedBrochures: int, stores: int, generated: int},
+     *     csv: array<string, mixed>,
+     *     import: array<string, mixed>,
+     *     importId: string|null,
+     * }
+     */
+    public function duplicateBrochuresPerSelectedStores(string $companyId, string $ownerId, array $brochureIds, array $storeNumbers): array
+    {
+        return $this->duplicateBrochuresInternal($companyId, $ownerId, $brochureIds, $storeNumbers);
+    }
+
+    /**
+     * @param array<int, int|string> $brochureIds
+     * @param array<int, int|string>|null $storeNumbers
+     *
+     * @return array{
+     *     summary: array{selectedBrochures: int, stores: int, generated: int},
+     *     csv: array<string, mixed>,
+     *     import: array<string, mixed>,
+     *     importId: string|null,
+     * }
+     */
+    private function duplicateBrochuresInternal(string $companyId, string $ownerId, array $brochureIds, ?array $storeNumbers): array
+    {
         $normalizedCompanyId = $this->normalizeIdentifier($companyId);
         $normalizedOwnerId = $this->normalizeIdentifier($ownerId);
         $normalizedBrochureIds = $this->normalizeIdentifiers($brochureIds);
+        $normalizedStoreNumbers = $storeNumbers === null ? null : $this->normalizeIdentifiers($storeNumbers);
 
         if ($normalizedCompanyId === '') {
             throw new InvalidArgumentException('A company must be selected to duplicate brochures.');
@@ -47,11 +81,40 @@ class BrochureActionService
             throw new InvalidArgumentException('Select at least one brochure to duplicate.');
         }
 
-        $stores = $this->iprotoService->getStoresByCompany($normalizedCompanyId);
-        $storeNumbers = $this->extractStoreNumbers($stores);
+        if ($normalizedStoreNumbers !== null && $normalizedStoreNumbers === []) {
+            throw new InvalidArgumentException('Select at least one store to duplicate brochures.');
+        }
 
-        if ($storeNumbers === []) {
+        $stores = $this->iprotoService->getStoresByCompany($normalizedCompanyId);
+        $availableStoreNumbers = $this->extractStoreNumbers($stores);
+
+        if ($availableStoreNumbers === []) {
             throw new \RuntimeException('No stores found for the selected company.');
+        }
+
+        $targetStoreNumbers = $availableStoreNumbers;
+
+        if ($normalizedStoreNumbers !== null) {
+            $reconciled = $this->reconcileSelectedStoreNumbers($normalizedStoreNumbers, $availableStoreNumbers);
+            $targetStoreNumbers = $reconciled['stores'];
+
+            if ($targetStoreNumbers === []) {
+                if ($reconciled['missing'] !== []) {
+                    throw new InvalidArgumentException(sprintf(
+                        'The following stores are not available for the selected company: %s.',
+                        implode(', ', $reconciled['missing'])
+                    ));
+                }
+
+                throw new InvalidArgumentException('Select at least one store to duplicate brochures.');
+            }
+
+            if ($reconciled['missing'] !== []) {
+                throw new InvalidArgumentException(sprintf(
+                    'The following stores are not available for the selected company: %s.',
+                    implode(', ', $reconciled['missing'])
+                ));
+            }
         }
 
         $duplicatedBrochures = [];
@@ -60,7 +123,7 @@ class BrochureActionService
             $brochureDetail = $this->iprotoService->getBrochureDetails($brochureId);
             $basePayload = $this->normalizeBrochurePayload($brochureDetail, $normalizedCompanyId, $brochureId);
 
-            foreach ($storeNumbers as $storeNumber) {
+            foreach ($targetStoreNumbers as $storeNumber) {
                 $payload = $basePayload;
                 $payload['brochureNumber'] = $this->buildBrochureNumberForStore($basePayload['brochureNumber'], $storeNumber);
                 $payload['storeNumber'] = $storeNumber;
@@ -96,7 +159,7 @@ class BrochureActionService
         return [
             'summary' => [
                 'selectedBrochures' => count($normalizedBrochureIds),
-                'stores' => count($storeNumbers),
+                'stores' => count($targetStoreNumbers),
                 'generated' => count($duplicatedBrochures),
             ],
             'csv' => $brochureCsv,
@@ -135,6 +198,47 @@ class BrochureActionService
         }
 
         return array_values($storeNumbers);
+    }
+
+    /**
+     * @param array<int, string> $selectedStoreNumbers
+     * @param array<int, string> $availableStoreNumbers
+     *
+     * @return array{stores: array<int, string>, missing: array<int, string>}
+     */
+    private function reconcileSelectedStoreNumbers(array $selectedStoreNumbers, array $availableStoreNumbers): array
+    {
+        $availableLookup = [];
+
+        foreach ($availableStoreNumbers as $storeNumber) {
+            $availableLookup[$storeNumber] = true;
+        }
+
+        $stores = [];
+        $missing = [];
+
+        foreach ($selectedStoreNumbers as $storeNumber) {
+            if ($storeNumber === '') {
+                continue;
+            }
+
+            if (isset($availableLookup[$storeNumber])) {
+                if (!in_array($storeNumber, $stores, true)) {
+                    $stores[] = $storeNumber;
+                }
+
+                continue;
+            }
+
+            if (!in_array($storeNumber, $missing, true)) {
+                $missing[] = $storeNumber;
+            }
+        }
+
+        return [
+            'stores' => $stores,
+            'missing' => $missing,
+        ];
     }
 
     private function buildBrochureNumberForStore(string $brochureNumber, string $storeNumber): string

--- a/src/Service/BookingWizard/BrochureActionService.php
+++ b/src/Service/BookingWizard/BrochureActionService.php
@@ -65,7 +65,15 @@ class BrochureActionService
                 $payload['brochureNumber'] = $this->buildBrochureNumberForStore($basePayload['brochureNumber'], $storeNumber);
                 $payload['storeNumber'] = $storeNumber;
 
-                $duplicatedBrochures[] = Brochure::fromArray($payload);
+                try {
+                    $duplicatedBrochures[] = Brochure::fromArray($payload);
+                } catch (\Throwable $exception) {
+                    throw new \RuntimeException(
+                        sprintf('Failed to duplicate brochure %s for store %s.', $brochureId, $storeNumber),
+                        0,
+                        $exception
+                    );
+                }
             }
         }
 
@@ -73,7 +81,11 @@ class BrochureActionService
             throw new \RuntimeException('No brochures were duplicated.');
         }
 
-        $brochureCsv = $this->csvService->createCsvFromBrochure($duplicatedBrochures, $normalizedCompanyId);
+        try {
+            $brochureCsv = $this->csvService->createCsvFromBrochure($duplicatedBrochures, $normalizedCompanyId);
+        } catch (\Throwable $exception) {
+            throw new \RuntimeException('Failed to create brochure CSV for duplication.', 0, $exception);
+        }
 
         try {
             $import = $this->iprotoService->importData($brochureCsv);
@@ -201,7 +213,13 @@ class BrochureActionService
         ];
 
         if (isset($brochure['pages']) && is_array($brochure['pages']) && $brochure['pages'] !== []) {
-            $candidates[] = $brochure['pages'][0];
+            foreach ($brochure['pages'] as $page) {
+                if (is_array($page)) {
+                    $candidates[] = $page['pdfUrl'] ?? $page['pdf_url'] ?? $page['url'] ?? $page['file'] ?? null;
+                } else {
+                    $candidates[] = $page;
+                }
+            }
         }
 
         foreach ($candidates as $candidate) {
@@ -251,6 +269,10 @@ class BrochureActionService
         if (is_array($value)) {
             $items = [];
             foreach ($value as $entry) {
+                if (is_array($entry)) {
+                    $entry = $entry['url'] ?? $entry['code'] ?? $entry['pixel'] ?? $entry['value'] ?? null;
+                }
+
                 $normalized = $this->normalizeScalar($entry);
                 if ($normalized !== '') {
                     $items[] = $normalized;
@@ -272,6 +294,9 @@ class BrochureActionService
         if (is_array($value)) {
             $items = [];
             foreach ($value as $entry) {
+                if (is_array($entry)) {
+                    $entry = $entry['name'] ?? $entry['title'] ?? $entry['label'] ?? $entry['value'] ?? null;
+                }
                 $normalized = $this->normalizeScalar($entry);
                 if ($normalized !== '') {
                     $items[] = $normalized;
@@ -342,7 +367,17 @@ class BrochureActionService
             return '';
         }
 
-        return trim($value);
+        $value = trim($value);
+
+        if ($value === '') {
+            return '';
+        }
+
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            $value = $this->sanitizeUtf8($value);
+        }
+
+        return $value;
     }
 
     private function normalizeIdentifier(mixed $value): string
@@ -428,5 +463,20 @@ class BrochureActionService
         $lastSegment = end($segments);
 
         return $lastSegment !== false ? $lastSegment : null;
+    }
+
+    private function sanitizeUtf8(string $value): string
+    {
+        $sanitized = @iconv('UTF-8', 'UTF-8//IGNORE', $value);
+        if (is_string($sanitized) && $sanitized !== '') {
+            return trim($sanitized);
+        }
+
+        $converted = @utf8_encode($value);
+        if (is_string($converted) && mb_check_encoding($converted, 'UTF-8')) {
+            return trim($converted);
+        }
+
+        return '';
     }
 }

--- a/src/Service/BookingWizard/BrochureActionService.php
+++ b/src/Service/BookingWizard/BrochureActionService.php
@@ -7,6 +7,7 @@ namespace App\Service\BookingWizard;
 use App\Dto\Brochure;
 use App\Service\CsvService;
 use App\Service\IprotoService;
+use App\Service\S3Service;
 use InvalidArgumentException;
 
 class BrochureActionService
@@ -14,10 +15,18 @@ class BrochureActionService
     public const ACTION_DUPLICATE_PER_STORE = 'duplicate_per_store';
     public const ACTION_DUPLICATE_SELECTED_STORES = 'duplicate_selected_stores';
 
+    /** @var array<string, string> */
+    private array $brochurePdfCache = [];
+
+    private bool $brochurePdfDirectoryEnsured = false;
+
     public function __construct(
         private IprotoService $iprotoService,
         private CsvService $csvService,
+        private S3Service $s3Service,
+        private string $brochurePdfDir = 'public/pdf',
     ) {
+        $this->brochurePdfDir = rtrim($brochurePdfDir, '/');
     }
 
     /**
@@ -122,6 +131,7 @@ class BrochureActionService
         foreach ($normalizedBrochureIds as $brochureId) {
             $brochureDetail = $this->iprotoService->getBrochureDetails($brochureId);
             $basePayload = $this->normalizeBrochurePayload($brochureDetail, $normalizedCompanyId, $brochureId);
+            $basePayload['pdfUrl'] = $this->preparePdfUrl($basePayload['pdfUrl'], $brochureId);
 
             foreach ($targetStoreNumbers as $storeNumber) {
                 $payload = $basePayload;
@@ -308,6 +318,54 @@ class BrochureActionService
         ];
     }
 
+    private function preparePdfUrl(string $pdfUrl, string $brochureId): string
+    {
+        $normalized = trim($pdfUrl);
+
+        if ($normalized === '') {
+            return '';
+        }
+
+        $pageId = $this->extractBrochurePageId($normalized);
+
+        if ($pageId === null) {
+            return $normalized;
+        }
+
+        if (isset($this->brochurePdfCache[$pageId])) {
+            return $this->brochurePdfCache[$pageId];
+        }
+
+        $this->ensureBrochurePdfDirectory();
+
+        $fileName = sprintf('brochure_%s.pdf', $pageId);
+        $destination = $this->brochurePdfDir . '/' . $fileName;
+
+        try {
+            $localPath = $this->iprotoService->downloadBrochurePdf($pageId, $destination);
+        } catch (\Throwable $exception) {
+            throw new \RuntimeException(
+                sprintf('Failed to download brochure PDF %s for brochure %s.', $pageId, $brochureId),
+                0,
+                $exception
+            );
+        }
+
+        try {
+            $uploadedUrl = $this->s3Service->upload($localPath);
+        } catch (\Throwable $exception) {
+            throw new \RuntimeException(
+                sprintf('Failed to upload brochure PDF %s for brochure %s.', $pageId, $brochureId),
+                0,
+                $exception
+            );
+        }
+
+        $this->brochurePdfCache[$pageId] = $uploadedUrl;
+
+        return $uploadedUrl;
+    }
+
     private function normalizePdfUrl(array $brochure): string
     {
         $candidates = [
@@ -334,6 +392,44 @@ class BrochureActionService
         }
 
         return '';
+    }
+
+    private function ensureBrochurePdfDirectory(): void
+    {
+        if ($this->brochurePdfDirectoryEnsured) {
+            return;
+        }
+
+        $directory = $this->brochurePdfDir;
+
+        if ($directory !== '' && !str_starts_with($directory, '/') && str_contains($directory, '://') === false) {
+            $workingDirectory = getcwd() ?: '';
+            if ($workingDirectory !== '') {
+                $directory = rtrim($workingDirectory, '/') . '/' . ltrim($directory, '/');
+            }
+        }
+
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, 0755, true) && !is_dir($directory)) {
+                throw new \RuntimeException(sprintf('Unable to create brochure PDF directory "%s".', $directory));
+            }
+        }
+
+        $this->brochurePdfDir = rtrim($directory, '/');
+        $this->brochurePdfDirectoryEnsured = true;
+    }
+
+    private function extractBrochurePageId(string $pdfUrl): ?string
+    {
+        if ($pdfUrl === '') {
+            return null;
+        }
+
+        if (preg_match('~brochure_pages/(\d+)~', $pdfUrl, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
     }
 
     private function normalizeSalesRegion(mixed $value): string

--- a/src/Service/BookingWizard/BrochureActionService.php
+++ b/src/Service/BookingWizard/BrochureActionService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\BookingWizard;
 
 use App\Dto\Brochure;
+use App\Dto\Product;
 use App\Service\CsvService;
 use App\Service\IprotoService;
 use App\Service\S3Service;
@@ -126,17 +127,120 @@ class BrochureActionService
             }
         }
 
-        $duplicatedBrochures = [];
+        $brochureMetadata = [];
+        $discoverLayouts = [];
+        $discoverProductsByBrochure = [];
+        $discoverProductDetails = [];
 
         foreach ($normalizedBrochureIds as $brochureId) {
             $brochureDetail = $this->iprotoService->getBrochureDetails($brochureId);
             $basePayload = $this->normalizeBrochurePayload($brochureDetail, $normalizedCompanyId, $brochureId);
             $basePayload['pdfUrl'] = $this->preparePdfUrl($basePayload['pdfUrl'], $brochureId);
 
+            $brochureMetadata[$brochureId] = [
+                'payload' => $basePayload,
+            ];
+
+            if (!$this->isDiscoverBrochure($basePayload)) {
+                continue;
+            }
+
+            $layoutData = $this->decodeDiscoverLayout($brochureDetail);
+            if ($layoutData === null) {
+                continue;
+            }
+
+            $discoverLayouts[$brochureId] = $layoutData;
+            $productIds = $this->collectDiscoverProductIds($layoutData);
+
+            if ($productIds === []) {
+                continue;
+            }
+
+            $discoverProductsByBrochure[$brochureId] = $productIds;
+
+            foreach ($productIds as $productId) {
+                if (isset($discoverProductDetails[$productId])) {
+                    continue;
+                }
+
+                $productDetail = $this->iprotoService->getProduct($productId);
+                $productNumber = $this->normalizeScalar($productDetail['productNumber'] ?? $productDetail['product_number'] ?? '');
+
+                if ($productNumber === '') {
+                    throw new \RuntimeException(sprintf(
+                        'Product %s referenced by brochure %s is missing a product number.',
+                        $productId,
+                        $brochureId
+                    ));
+                }
+
+                $discoverProductDetails[$productId] = [
+                    'number' => $productNumber,
+                    'data' => $productDetail,
+                ];
+            }
+        }
+
+        $productArticleLookup = [];
+        $productIdLookup = [];
+
+        if ($discoverProductDetails !== []) {
+            $productPreparation = $this->prepareDiscoverProductsForStores(
+                $discoverProductDetails,
+                $discoverProductsByBrochure,
+                $targetStoreNumbers,
+                $normalizedCompanyId,
+            );
+
+            $productArticleLookup = $productPreparation['lookup'];
+
+            if ($productPreparation['products'] !== []) {
+                try {
+                    $productCsv = $this->csvService->createCsvFromProducts($productPreparation['products'], $normalizedCompanyId);
+                } catch (\Throwable $exception) {
+                    throw new \RuntimeException('Failed to create product CSV for brochure duplication.', 0, $exception);
+                }
+
+                try {
+                    $this->iprotoService->importData($productCsv);
+                } catch (\Throwable $exception) {
+                    throw new \RuntimeException('Failed to import duplicated products.', 0, $exception);
+                }
+
+                $productRecords = $this->waitForDuplicatedProducts($normalizedCompanyId, $productPreparation['articleNumbers']);
+                $productIdLookup = $this->mapProductIdsByArticle($productRecords);
+            }
+        }
+
+        $duplicatedBrochures = [];
+
+        foreach ($normalizedBrochureIds as $brochureId) {
+            $metadata = $brochureMetadata[$brochureId] ?? null;
+
+            if ($metadata === null) {
+                continue;
+            }
+
+            $basePayload = $metadata['payload'];
+            $layoutData = $discoverLayouts[$brochureId] ?? null;
+
             foreach ($targetStoreNumbers as $storeNumber) {
                 $payload = $basePayload;
                 $payload['brochureNumber'] = $this->buildBrochureNumberForStore($basePayload['brochureNumber'], $storeNumber);
                 $payload['storeNumber'] = $storeNumber;
+
+                if ($layoutData !== null) {
+                    $productIdMap = $this->buildProductIdMapForStore($productArticleLookup, $productIdLookup, $brochureId, $storeNumber);
+
+                    if ($productIdMap !== []) {
+                        $updatedLayout = $this->buildDiscoverLayoutForStore($layoutData, $productIdMap);
+
+                        if ($updatedLayout !== null) {
+                            $payload['layout'] = $updatedLayout;
+                        }
+                    }
+                }
 
                 try {
                     $duplicatedBrochures[] = Brochure::fromArray($payload);
@@ -267,6 +371,22 @@ class BrochureActionService
         return sprintf('%s_%s', $normalizedBrochure, $normalizedStore);
     }
 
+    private function buildProductNumberForStore(string $productNumber, string $storeNumber): string
+    {
+        $normalizedProduct = $this->normalizeIdentifier($productNumber);
+        $normalizedStore = $this->normalizeIdentifier(preg_replace('/\s+/', '', $storeNumber) ?? $storeNumber);
+
+        if ($normalizedProduct === '') {
+            return $normalizedStore;
+        }
+
+        if ($normalizedStore === '') {
+            return $normalizedProduct;
+        }
+
+        return sprintf('%s_%s', $normalizedProduct, $normalizedStore);
+    }
+
     /**
      * @param array<string, mixed> $brochure
      *
@@ -364,6 +484,388 @@ class BrochureActionService
         $this->brochurePdfCache[$brochureId] = $uploadedUrl;
 
         return $uploadedUrl;
+    }
+
+    private function isDiscoverBrochure(array $payload): bool
+    {
+        $type = strtolower($this->normalizeScalar($payload['type'] ?? ''));
+
+        return $type === 'discover';
+    }
+
+    private function decodeDiscoverLayout(array $brochure): ?array
+    {
+        $layout = $brochure['layout'] ?? null;
+
+        if (is_string($layout) && $layout !== '') {
+            $decoded = json_decode($layout, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        if (is_array($layout)) {
+            return $layout;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<mixed> $layout
+     * @return array<int, string>
+     */
+    private function collectDiscoverProductIds(array $layout): array
+    {
+        $ids = [];
+
+        $this->walkDiscoverLayout($layout, static function (string $id) use (&$ids): void {
+            $ids[$id] = $id;
+        });
+
+        return array_values($ids);
+    }
+
+    /**
+     * @param array<mixed> $node
+     */
+    private function walkDiscoverLayout(array $node, callable $collector): void
+    {
+        if (isset($node['products']) && is_array($node['products'])) {
+            foreach ($node['products'] as $product) {
+                if (!is_array($product)) {
+                    continue;
+                }
+
+                $id = $product['id'] ?? null;
+                if ($id === null) {
+                    continue;
+                }
+
+                $collector((string) $id);
+            }
+        }
+
+        foreach ($node as $value) {
+            if (is_array($value)) {
+                $this->walkDiscoverLayout($value, $collector);
+            }
+        }
+    }
+
+    /**
+     * @param array<mixed> $layoutData
+     * @param array<string, int|string> $productIdMap
+     */
+    private function buildDiscoverLayoutForStore(array $layoutData, array $productIdMap): ?string
+    {
+        if ($productIdMap === []) {
+            return null;
+        }
+
+        $updated = $this->replaceDiscoverProductIds($layoutData, $productIdMap);
+        $encoded = json_encode($updated, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        if ($encoded === false) {
+            throw new \RuntimeException('Failed to encode discover brochure layout.');
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * @param array<mixed> $node
+     * @param array<string, int|string> $productIdMap
+     * @return array<mixed>
+     */
+    private function replaceDiscoverProductIds(array $node, array $productIdMap): array
+    {
+        $result = [];
+
+        foreach ($node as $key => $value) {
+            if (is_array($value)) {
+                if ($key === 'products') {
+                    $products = [];
+                    foreach ($value as $product) {
+                        if (!is_array($product)) {
+                            $products[] = $product;
+                            continue;
+                        }
+
+                        $productCopy = $this->replaceDiscoverProductIds($product, $productIdMap);
+
+                        if (isset($productCopy['id'])) {
+                            $idKey = (string) $productCopy['id'];
+                            if (isset($productIdMap[$idKey])) {
+                                $replacement = $productIdMap[$idKey];
+                                $productCopy['id'] = is_numeric($replacement) ? (int) $replacement : $replacement;
+                            }
+                        }
+
+                        $products[] = $productCopy;
+                    }
+
+                    $result[$key] = $products;
+                    continue;
+                }
+
+                $result[$key] = $this->replaceDiscoverProductIds($value, $productIdMap);
+                continue;
+            }
+
+            if ($key === 'id') {
+                $idKey = (string) $value;
+                if (isset($productIdMap[$idKey])) {
+                    $replacement = $productIdMap[$idKey];
+                    $result[$key] = is_numeric($replacement) ? (int) $replacement : $replacement;
+                    continue;
+                }
+            }
+
+            $result[$key] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, array<string, array<string, string>>> $articleLookup
+     * @param array<string, int|string> $productIdLookup
+     * @return array<string, int|string>
+     */
+    private function buildProductIdMapForStore(array $articleLookup, array $productIdLookup, string $brochureId, string $storeNumber): array
+    {
+        if (!isset($articleLookup[$brochureId][$storeNumber])) {
+            return [];
+        }
+
+        $map = [];
+
+        foreach ($articleLookup[$brochureId][$storeNumber] as $originalProductId => $articleNumber) {
+            if (!isset($productIdLookup[$articleNumber])) {
+                throw new \RuntimeException(sprintf(
+                    'Duplicated product "%s" for brochure %s and store %s is not available.',
+                    $articleNumber,
+                    $brochureId,
+                    $storeNumber
+                ));
+            }
+
+            $map[(string) $originalProductId] = $productIdLookup[$articleNumber];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string|int, array{number: string, data: array<string, mixed>}> $productDetails
+     * @param array<string, array<int, string>> $productsByBrochure
+     * @param array<int, string> $storeNumbers
+     * @return array{
+     *     products: array<int, Product>,
+     *     articleNumbers: array<int, string>,
+     *     lookup: array<string, array<string, array<string, string>>>
+     * }
+     */
+    private function prepareDiscoverProductsForStores(
+        array $productDetails,
+        array $productsByBrochure,
+        array $storeNumbers,
+        string $companyId,
+    ): array {
+        $products = [];
+        $lookup = [];
+
+        foreach ($productsByBrochure as $brochureId => $productIds) {
+            foreach ($storeNumbers as $storeNumber) {
+                foreach ($productIds as $productId) {
+                    if (!isset($productDetails[$productId])) {
+                        continue;
+                    }
+
+                    $detail = $productDetails[$productId];
+                    $newNumber = $this->buildProductNumberForStore($detail['number'], $storeNumber);
+
+                    $lookup[$brochureId][$storeNumber][(string) $productId] = $newNumber;
+
+                    if (!isset($products[$newNumber])) {
+                        $products[$newNumber] = $this->createProductDtoForStore(
+                            $detail['data'],
+                            $newNumber,
+                            $companyId,
+                            $storeNumber,
+                        );
+                    }
+                }
+            }
+        }
+
+        return [
+            'products' => array_values($products),
+            'articleNumbers' => array_keys($products),
+            'lookup' => $lookup,
+        ];
+    }
+
+    private function createProductDtoForStore(
+        array $productData,
+        string $newProductNumber,
+        string $companyId,
+        string $storeNumber,
+    ): Product {
+        $integrationId = $this->extractIdFromIri($productData['integration'] ?? null) ?? $companyId;
+
+        $payload = [
+            'integration' => $integrationId,
+            'productNumber' => $newProductNumber,
+            'title' => $this->normalizeScalar($productData['title'] ?? ''),
+            'description' => $this->normalizeScalar($productData['description'] ?? ''),
+            'price' => $this->normalizeScalar($productData['price'] ?? ''),
+            'currency' => $this->normalizeScalar($productData['currency'] ?? ''),
+            'secondaryPrice' => $this->normalizeScalar($productData['secondaryPrice'] ?? ''),
+            'secondaryCurrency' => $this->normalizeScalar($productData['secondaryCurrency'] ?? ''),
+            'priceIsVariable' => $this->normalizeBooleanFlag($productData['priceIsVariable'] ?? null),
+            'manufacturerPrice' => $this->normalizeScalar($productData['manufacturerPrice'] ?? ''),
+            'secondaryManufacturerPrice' => $this->normalizeScalar($productData['secondaryManufacturerPrice'] ?? ''),
+            'manufacturerNumber' => $this->normalizeScalar($productData['manufacturerNumber'] ?? ''),
+            'gtin' => $this->normalizeScalar($productData['gtin'] ?? ''),
+            'languageCode' => $this->normalizeScalar($productData['languageCode'] ?? ''),
+            'keywords' => $this->normalizeProductKeywords($productData['keywords'] ?? null),
+            'trackingPixels' => $this->normalizeProductTrackingPixels($productData['trackingPixels'] ?? null),
+            'url' => $this->normalizeScalar($productData['url'] ?? ''),
+            'brandText' => $this->normalizeScalar($productData['brandText'] ?? ''),
+            'brandImage' => $this->normalizeScalar($productData['brandImage'] ?? ''),
+            'amount' => $this->normalizeScalar($productData['amount'] ?? ''),
+            'size' => $this->normalizeScalar($productData['size'] ?? ''),
+            'color' => $this->normalizeScalar($productData['color'] ?? ''),
+            'unitType' => $this->normalizeScalar($productData['unitType'] ?? ''),
+            'subTitle' => $this->normalizeScalar($productData['subTitle'] ?? ''),
+            'salesRegion' => $this->normalizeSalesRegion($productData['salesRegion'] ?? null),
+            'validFrom' => $this->normalizeScalar($productData['validFrom'] ?? ''),
+            'validTo' => $this->normalizeScalar($productData['validTo'] ?? ''),
+            'visibleFrom' => $this->normalizeScalar($productData['visibleFrom'] ?? ''),
+            'hidden' => $this->normalizeBooleanFlag($productData['hidden'] ?? null),
+            'additionalProperties' => $this->normalizeScalar($productData['additionalProperties'] ?? ''),
+            'shipping' => $this->normalizeScalar($productData['shipping'] ?? ''),
+            'variants' => $this->normalizeProductVariants($productData['variants'] ?? null),
+        ];
+
+        return Product::fromArray($payload);
+    }
+
+    /**
+     * @param array<int, string> $articleNumbers
+     * @return array<string, array<string, mixed>>
+     */
+    private function waitForDuplicatedProducts(string $companyId, array $articleNumbers): array
+    {
+        $pending = array_values(array_unique(array_map('strval', $articleNumbers)));
+
+        if ($pending === []) {
+            return [];
+        }
+
+        $results = [];
+        $attempts = 0;
+        $maxAttempts = 60;
+
+        while ($pending !== [] && $attempts < $maxAttempts) {
+            foreach ($pending as $index => $articleNumber) {
+                try {
+                    $product = $this->iprotoService->findProductsByNumber($companyId, $articleNumber);
+                } catch (\Throwable $exception) {
+                    throw new \RuntimeException(sprintf('Unable to load duplicated product "%s".', $articleNumber), 0, $exception);
+                }
+
+                if ($product !== false) {
+                    $results[$articleNumber] = $product;
+                    unset($pending[$index]);
+                }
+            }
+
+            if ($pending === []) {
+                break;
+            }
+
+            ++$attempts;
+            $pending = array_values($pending);
+            usleep(500000);
+        }
+
+        if ($pending !== []) {
+            throw new \RuntimeException('Timed out waiting for duplicated products to become available.');
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $productRecords
+     * @return array<string, int|string>
+     */
+    private function mapProductIdsByArticle(array $productRecords): array
+    {
+        $map = [];
+
+        foreach ($productRecords as $articleNumber => $record) {
+            $id = $record['id'] ?? null;
+
+            if ($id === null) {
+                continue;
+            }
+
+            $map[$articleNumber] = is_numeric($id) ? (int) $id : (string) $id;
+        }
+
+        return $map;
+    }
+
+    private function normalizeBooleanFlag(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_int($value)) {
+            return $value !== 0 ? '1' : '0';
+        }
+
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+
+            if ($normalized === '') {
+                return '0';
+            }
+
+            return in_array($normalized, ['1', 'true', 'yes', 'on'], true) ? '1' : '0';
+        }
+
+        return '0';
+    }
+
+    private function normalizeProductKeywords(mixed $value): string
+    {
+        return $this->normalizeTags($value);
+    }
+
+    private function normalizeProductTrackingPixels(mixed $value): string
+    {
+        return $this->normalizeTrackingPixels($value);
+    }
+
+    private function normalizeProductVariants(mixed $value): string
+    {
+        if (is_string($value)) {
+            return trim($value);
+        }
+
+        if (is_array($value) && $value !== []) {
+            $encoded = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+            return $encoded === false ? '' : $encoded;
+        }
+
+        return '';
     }
 
     private function normalizePdfUrl(array $brochure): string

--- a/src/Service/BookingWizard/BrochureActionService.php
+++ b/src/Service/BookingWizard/BrochureActionService.php
@@ -9,6 +9,7 @@ use App\Dto\Product;
 use App\Service\CsvService;
 use App\Service\IprotoService;
 use App\Service\S3Service;
+use Closure;
 use InvalidArgumentException;
 
 class BrochureActionService
@@ -21,13 +22,29 @@ class BrochureActionService
 
     private bool $brochurePdfDirectoryEnsured = false;
 
+    private Closure $productSleepCallback;
+
+    private int $productPollAttempts;
+
+    private int $productPollIntervalSeconds;
+
     public function __construct(
         private IprotoService $iprotoService,
         private CsvService $csvService,
         private S3Service $s3Service,
         private string $brochurePdfDir = 'public/pdf',
+        ?Closure $productSleepCallback = null,
+        int $productPollAttempts = 7,
+        int $productPollIntervalSeconds = 180,
     ) {
         $this->brochurePdfDir = rtrim($brochurePdfDir, '/');
+        $this->productSleepCallback = $productSleepCallback ?? static function (int $seconds): void {
+            if ($seconds > 0) {
+                sleep($seconds);
+            }
+        };
+        $this->productPollAttempts = max(1, $productPollAttempts);
+        $this->productPollIntervalSeconds = max(0, $productPollIntervalSeconds);
     }
 
     /**
@@ -766,10 +783,12 @@ class BrochureActionService
         }
 
         $results = [];
-        $attempts = 0;
-        $maxAttempts = 60;
+        $attempt = 0;
+        $maxAttempts = $this->productPollAttempts;
 
-        while ($pending !== [] && $attempts < $maxAttempts) {
+        while ($pending !== [] && $attempt < $maxAttempts) {
+            $this->pauseBeforeProductCheck();
+
             foreach ($pending as $index => $articleNumber) {
                 try {
                     $product = $this->iprotoService->findProductsByNumber($companyId, $articleNumber);
@@ -787,16 +806,26 @@ class BrochureActionService
                 break;
             }
 
-            ++$attempts;
+            ++$attempt;
             $pending = array_values($pending);
-            usleep(500000);
         }
 
         if ($pending !== []) {
-            throw new \RuntimeException('Timed out waiting for duplicated products to become available.');
+            throw new \RuntimeException('Product import failed to complete.');
         }
 
         return $results;
+    }
+
+    private function pauseBeforeProductCheck(): void
+    {
+        $seconds = $this->productPollIntervalSeconds;
+
+        if ($seconds <= 0) {
+            return;
+        }
+
+        ($this->productSleepCallback)($seconds);
     }
 
     /**

--- a/src/Service/CsvService.php
+++ b/src/Service/CsvService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Dto\Product;
 use App\Dto\Store;
 use League\Csv\Writer;
 use SplTempFileObject;
@@ -205,6 +206,59 @@ class CsvService
         return [
             'companyId' => $companyId,
             'type' => 'brochures',
+            'filePath' => $filePath,
+            'message' => "CSV created successfully: {$fileName}. \n Download at http://127.0.0.1:8000/csv/{$fileName}",
+            'downloadLink' => $domain . "http://127.0.0.1:8000/csv/{$fileName}",
+            'base64' => $base64Csv,
+        ];
+    }
+
+    /**
+     * @param array<int, Product> $products
+     */
+    public function createCsvFromProducts(array $products, string $companyId): array
+    {
+        if ($products === []) {
+            throw new \RuntimeException('No products to export.');
+        }
+
+        $csv = Writer::createFromFileObject(new SplTempFileObject());
+        $csv->insertOne(Product::CSV_HEADERS);
+
+        foreach ($products as $product) {
+            if (!$product instanceof Product) {
+                throw new \InvalidArgumentException('Expected array of Dto\\Product objects.');
+            }
+
+            $row = [];
+            $data = $product->toArray();
+
+            foreach (Product::CSV_HEADERS as $header) {
+                $row[] = $data[$header] ?? '';
+            }
+
+            $csv->insertOne($row);
+        }
+
+        $timestamp = round(microtime(true) * 1000);
+        $fileName = sprintf('products_%s_%d.csv', $companyId, $timestamp);
+        $filePath = rtrim($this->csvDir, '/') . '/' . $fileName;
+
+        $directory = dirname($filePath);
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, 0755, true) && !is_dir($directory)) {
+                throw new \RuntimeException(sprintf('Directory "%s" was not created', $directory));
+            }
+        }
+
+        $csvContent = $csv->toString();
+        file_put_contents($filePath, $csvContent);
+        $base64Csv = base64_encode($csvContent);
+        $domain = getenv('APP_DOMAIN');
+
+        return [
+            'companyId' => $companyId,
+            'type' => 'products',
             'filePath' => $filePath,
             'message' => "CSV created successfully: {$fileName}. \n Download at http://127.0.0.1:8000/csv/{$fileName}",
             'downloadLink' => $domain . "http://127.0.0.1:8000/csv/{$fileName}",

--- a/src/Service/IprotoService.php
+++ b/src/Service/IprotoService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -196,6 +197,64 @@ class IprotoService
         }
 
         return $data;
+    }
+
+    public function downloadBrochurePdf(string $brochurePageId, string $destinationPath): string
+    {
+        $pageId = trim($brochurePageId);
+
+        if ($pageId === '') {
+            throw new InvalidArgumentException('Brochure page ID is required to download the PDF.');
+        }
+
+        $uri = sprintf('/api/stashed_files/brochures/%s', rawurlencode($pageId));
+
+        $token = $this->tokenService->getValidToken();
+        if ($token === '') {
+            throw new \RuntimeException('Unable to download brochure PDF without a valid token.');
+        }
+
+        $url = $this->buildUrl($uri);
+        $options = [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'Accept' => 'application/pdf',
+            ],
+            'http_version' => '1.1',
+        ];
+
+        try {
+            $response = $this->httpClient->request('GET', $url, $options);
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode >= 300) {
+                $this->logger->warning(sprintf(
+                    'Failed to download brochure PDF %s: status %d, body: %s',
+                    $pageId,
+                    $statusCode,
+                    $response->getContent(false)
+                ));
+
+                throw new \RuntimeException(sprintf('Unable to download brochure PDF %s (status %d).', $pageId, $statusCode));
+            }
+
+            $content = $response->getContent();
+        } catch (\Throwable $exception) {
+            throw new \RuntimeException(sprintf('Unable to download brochure PDF %s.', $pageId), 0, $exception);
+        }
+
+        $directory = dirname($destinationPath);
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, 0755, true) && !is_dir($directory)) {
+                throw new \RuntimeException(sprintf('Unable to create directory "%s" for brochure PDF.', $directory));
+            }
+        }
+
+        if (file_put_contents($destinationPath, $content) === false) {
+            throw new \RuntimeException(sprintf('Unable to write brochure PDF %s to "%s".', $pageId, $destinationPath));
+        }
+
+        return $destinationPath;
     }
 
     /**

--- a/src/Service/IprotoService.php
+++ b/src/Service/IprotoService.php
@@ -199,15 +199,20 @@ class IprotoService
         return $data;
     }
 
-    public function downloadBrochurePdf(string $brochurePageId, string $destinationPath): string
+    public function downloadBrochurePdf(string $brochurePageId, string $destinationPath, string $brochureId): string
     {
         $pageId = trim($brochurePageId);
+        $normalizedBrochureId = trim($brochureId);
 
         if ($pageId === '') {
             throw new InvalidArgumentException('Brochure page ID is required to download the PDF.');
         }
 
-        $uri = sprintf('/api/stashed_files/brochures/%s', rawurlencode($pageId));
+        if ($normalizedBrochureId === '') {
+            throw new InvalidArgumentException('Brochure ID is required to download the PDF.');
+        }
+
+        $uri = sprintf('/api/stashed_files/brochures/%s', rawurlencode($normalizedBrochureId));
 
         $token = $this->tokenService->getValidToken();
         if ($token === '') {
@@ -229,18 +234,27 @@ class IprotoService
 
             if ($statusCode < 200 || $statusCode >= 300) {
                 $this->logger->warning(sprintf(
-                    'Failed to download brochure PDF %s: status %d, body: %s',
+                    'Failed to download brochure PDF %s (page %s): status %d, body: %s',
+                    $normalizedBrochureId,
                     $pageId,
                     $statusCode,
                     $response->getContent(false)
                 ));
 
-                throw new \RuntimeException(sprintf('Unable to download brochure PDF %s (status %d).', $pageId, $statusCode));
+                throw new \RuntimeException(sprintf(
+                    'Unable to download brochure PDF %s (status %d).',
+                    $normalizedBrochureId,
+                    $statusCode
+                ));
             }
 
             $content = $response->getContent();
         } catch (\Throwable $exception) {
-            throw new \RuntimeException(sprintf('Unable to download brochure PDF %s.', $pageId), 0, $exception);
+            throw new \RuntimeException(
+                sprintf('Unable to download brochure PDF %s.', $normalizedBrochureId),
+                0,
+                $exception
+            );
         }
 
         $directory = dirname($destinationPath);
@@ -251,7 +265,11 @@ class IprotoService
         }
 
         if (file_put_contents($destinationPath, $content) === false) {
-            throw new \RuntimeException(sprintf('Unable to write brochure PDF %s to "%s".', $pageId, $destinationPath));
+            throw new \RuntimeException(sprintf(
+                'Unable to write brochure PDF %s to "%s".',
+                $normalizedBrochureId,
+                $destinationPath
+            ));
         }
 
         return $destinationPath;

--- a/src/Service/IprotoService.php
+++ b/src/Service/IprotoService.php
@@ -73,6 +73,35 @@ class IprotoService
         return $response['body'];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function getProduct(int|string $productId): array
+    {
+        $normalizedId = trim((string) $productId);
+
+        if ($normalizedId === '') {
+            throw new InvalidArgumentException('Product ID is required to fetch a product.');
+        }
+
+        $response = $this->sendRequest(
+            'GET',
+            sprintf('/api/products/%s', rawurlencode($normalizedId)),
+            [],
+            null,
+            'application/ld+json',
+            'application/ld+json',
+        );
+
+        $body = $response['body'];
+
+        if (!is_array($body)) {
+            throw new \RuntimeException(sprintf('Unexpected response while fetching product "%s" from iProto.', $normalizedId));
+        }
+
+        return $body;
+    }
+
 
     /**
      * @param array<string, mixed> $options

--- a/src/Service/IprotoService.php
+++ b/src/Service/IprotoService.php
@@ -102,6 +102,51 @@ class IprotoService
         return $body;
     }
 
+    /**
+     * @return array<string, mixed>|false
+     */
+    public function findProductsByNumber(int|string $companyId, string $articleNumber)
+    {
+        $normalizedCompanyId = trim((string) $companyId);
+        $normalizedArticle = trim($articleNumber);
+
+        if ($normalizedCompanyId === '' || $normalizedArticle === '') {
+            throw new InvalidArgumentException('Company ID and product number are required to locate a product.');
+        }
+
+        $response = $this->sendRequest('GET', '/api/products', [
+            'integration' => '/api/integrations/' . ltrim($normalizedCompanyId, '/'),
+            'productNumber' => $normalizedArticle,
+            'exists' => [
+                'deletedAt' => false,
+            ],
+            'timeConstraint' => [
+                'future' => true,
+            ],
+            'itemsPerPage' => 1,
+        ])['body'];
+
+        if (!is_array($response) || !isset($response['hydra:totalItems'])) {
+            throw new \RuntimeException('Unexpected product search response received from iProto.');
+        }
+
+        if ((int) $response['hydra:totalItems'] === 0) {
+            return false;
+        }
+
+        $items = $response['hydra:member'] ?? [];
+        if (!is_array($items)) {
+            return false;
+        }
+
+        $first = reset($items);
+        if (!is_array($first)) {
+            return false;
+        }
+
+        return $this->mapProductToApi3($first);
+    }
+
 
     /**
      * @param array<string, mixed> $options
@@ -740,6 +785,104 @@ class IprotoService
         $lastSegment = end($segments);
 
         return $lastSegment !== false ? $lastSegment : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapProductToApi3(array $product): array
+    {
+        $id = $product['id'] ?? null;
+
+        if ($id === null && isset($product['@id'])) {
+            $id = $this->extractIntegrationId($product['@id']);
+        }
+
+        if (is_numeric($id)) {
+            $id = (int) $id;
+        } elseif ($id !== null) {
+            $id = (string) $id;
+        }
+
+        return [
+            'id' => $id,
+            'productNumber' => $this->normalizeProductString($product['productNumber'] ?? $product['product_number'] ?? ''),
+            'title' => $this->normalizeProductString($product['title'] ?? ''),
+            'description' => $this->normalizeProductString($product['description'] ?? ''),
+            'price' => $this->normalizeProductString($product['price'] ?? ''),
+            'currency' => $this->normalizeProductString($product['currency'] ?? ''),
+            'secondaryPrice' => $this->normalizeProductString($product['secondaryPrice'] ?? ''),
+            'secondaryCurrency' => $this->normalizeProductString($product['secondaryCurrency'] ?? ''),
+            'manufacturerPrice' => $this->normalizeProductString($product['manufacturerPrice'] ?? ''),
+            'secondaryManufacturerPrice' => $this->normalizeProductString($product['secondaryManufacturerPrice'] ?? ''),
+            'manufacturerNumber' => $this->normalizeProductString($product['manufacturerNumber'] ?? ''),
+            'gtin' => $this->normalizeProductString($product['gtin'] ?? ''),
+            'languageCode' => $this->normalizeProductString($product['languageCode'] ?? ''),
+            'keywords' => $this->normalizeProductList($product['keywords'] ?? null),
+            'trackingPixels' => $this->normalizeProductList($product['trackingPixels'] ?? null),
+            'url' => $this->normalizeProductString($product['url'] ?? ''),
+            'brandText' => $this->normalizeProductString($product['brandText'] ?? ''),
+            'brandImage' => $this->normalizeProductString($product['brandImage'] ?? ''),
+            'amount' => $this->normalizeProductString($product['amount'] ?? ''),
+            'size' => $this->normalizeProductString($product['size'] ?? ''),
+            'color' => $this->normalizeProductString($product['color'] ?? ''),
+            'unitType' => $this->normalizeProductString($product['unitType'] ?? ''),
+            'subTitle' => $this->normalizeProductString($product['subTitle'] ?? ''),
+            'salesRegion' => $this->normalizeProductString($product['salesRegion'] ?? ''),
+            'validFrom' => $this->normalizeProductString($product['validFrom'] ?? ''),
+            'validTo' => $this->normalizeProductString($product['validTo'] ?? ''),
+            'visibleFrom' => $this->normalizeProductString($product['visibleFrom'] ?? ''),
+            'hidden' => $product['hidden'] ?? false,
+            'priceIsVariable' => $product['priceIsVariable'] ?? false,
+            'additionalProperties' => $this->normalizeProductString($product['additionalProperties'] ?? ''),
+            'shipping' => $this->normalizeProductString($product['shipping'] ?? ''),
+            'integration' => $this->normalizeProductString($product['integration'] ?? ''),
+            'variants' => is_array($product['variants'] ?? null) ? $product['variants'] : [],
+            'raw' => $product,
+        ];
+    }
+
+    private function normalizeProductString(mixed $value): string
+    {
+        if ($value instanceof \Stringable) {
+            $value = (string) $value;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        }
+
+        if (!is_string($value)) {
+            return '';
+        }
+
+        return trim($value);
+    }
+
+    private function normalizeProductList(mixed $value): string
+    {
+        if (is_string($value)) {
+            return trim($value);
+        }
+
+        if (is_array($value)) {
+            $items = [];
+
+            foreach ($value as $entry) {
+                if (is_array($entry)) {
+                    $entry = $entry['value'] ?? $entry['url'] ?? $entry['label'] ?? $entry['code'] ?? null;
+                }
+
+                $normalized = $this->normalizeProductString($entry);
+                if ($normalized !== '') {
+                    $items[] = $normalized;
+                }
+            }
+
+            return implode(', ', $items);
+        }
+
+        return '';
     }
 
     public function importData(array $data): array

--- a/src/Service/IprotoService.php
+++ b/src/Service/IprotoService.php
@@ -583,8 +583,13 @@ class IprotoService
 
         // Now $data is in the expected format
         $response = $this->sendRequest('POST', '/api/imports', [], $data, 'application/ld+json', 'application/ld+json');
+        $body = $response['body'];
 
-        return $response['body'];
+        if (!is_array($body)) {
+            throw new \RuntimeException('Unexpected import response received from iProto.');
+        }
+
+        return $body;
     }
 
     public function getImportStatus($importId): array

--- a/src/Service/IprotoService.php
+++ b/src/Service/IprotoService.php
@@ -75,9 +75,10 @@ class IprotoService
 
 
     /**
+     * @param array<string, mixed> $options
      * @return array<int, array<string, mixed>>
      */
-    public function getBrochuresByOwnerAndCompany(string $ownerId, string $companyId, int $itemsPerPage = 100): array
+    public function getBrochuresByOwnerAndCompany(string $ownerId, string $companyId, array $options = []): array
     {
         $ownerId = trim($ownerId);
         $companyId = trim($companyId);
@@ -86,7 +87,8 @@ class IprotoService
             throw new \InvalidArgumentException('Owner ID and company ID are required to fetch brochures.');
         }
 
-        $itemsPerPage = max(1, min($itemsPerPage, 200));
+        $itemsPerPageOption = $options['itemsPerPage'] ?? 100;
+        $itemsPerPage = max(1, min((int) $itemsPerPageOption, 200));
         $integrationId = trim((string) ($this->extractIntegrationId($companyId) ?? $companyId));
         if ($integrationId === '') {
             $integrationId = $companyId;
@@ -97,6 +99,68 @@ class IprotoService
         $results = [];
         $remainingIterations = 200;
 
+        $orderOptions = $options['order'] ?? ['id' => 'desc'];
+        if (!is_array($orderOptions)) {
+            $orderOptions = ['id' => 'desc'];
+        }
+
+        $order = [];
+        foreach ($orderOptions as $field => $direction) {
+            if (!is_string($field)) {
+                continue;
+            }
+
+            $normalizedField = trim($field);
+            if ($normalizedField === '') {
+                continue;
+            }
+
+            $normalizedDirection = is_string($direction) ? strtolower(trim($direction)) : 'asc';
+            $order[$normalizedField] = $normalizedDirection === 'desc' ? 'desc' : 'asc';
+        }
+
+        if (empty($order)) {
+            $order = ['id' => 'desc'];
+        }
+
+        $deletedFilter = isset($options['deletedFilter']) && is_string($options['deletedFilter'])
+            ? strtolower(trim($options['deletedFilter']))
+            : 'active';
+
+        $deletedExists = null;
+        if ($deletedFilter === 'deleted') {
+            $deletedExists = true;
+        } elseif ($deletedFilter === 'active' || $deletedFilter === 'not_deleted') {
+            $deletedExists = false;
+        }
+
+        $timeConstraints = ['current', 'upcoming'];
+        if (array_key_exists('timeConstraints', $options)) {
+            $timeConstraints = [];
+            $constraintsOption = $options['timeConstraints'];
+
+            if (is_array($constraintsOption)) {
+                foreach ($constraintsOption as $constraint) {
+                    if (!is_string($constraint)) {
+                        continue;
+                    }
+
+                    $normalizedConstraint = strtolower(trim($constraint));
+                    if ($normalizedConstraint === '') {
+                        continue;
+                    }
+
+                    if (!in_array($normalizedConstraint, ['current', 'upcoming', 'past'], true)) {
+                        continue;
+                    }
+
+                    if (!in_array($normalizedConstraint, $timeConstraints, true)) {
+                        $timeConstraints[] = $normalizedConstraint;
+                    }
+                }
+            }
+        }
+
         do {
             $params = [
                 'owner' => $ownerId,
@@ -104,18 +168,21 @@ class IprotoService
                 'integration.id' => $integrationId,
                 'itemsPerPage' => $itemsPerPage,
                 'page' => $page,
-                'exists' => [
-                    'deletedAt' => false,
-                ],
-                'order' => [
-                    'id' => 'asc',
-                    'title' => 'asc',
-                    'brochureNumber' => 'asc',
-                    'validFrom' => 'asc',
-                    'visibleFrom' => 'asc',
-                    'validTo' => 'asc',
-                ],
+                'order' => $order,
             ];
+
+            if ($deletedExists !== null) {
+                $params['exists'] = [
+                    'deletedAt' => $deletedExists,
+                ];
+            }
+
+            if (!empty($timeConstraints)) {
+                $params['timeConstraint'] = [];
+                foreach ($timeConstraints as $constraint) {
+                    $params['timeConstraint'][$constraint] = true;
+                }
+            }
 
             $response = $this->sendRequest(
                 'GET',

--- a/src/Service/S3Service.php
+++ b/src/Service/S3Service.php
@@ -13,8 +13,13 @@ class S3Service
     private string $bucket;
     private string $region;
 
-    public function __construct(string $bucket, string $region, ?string $profile = null)
-    {
+    public function __construct(
+        string $bucket,
+        string $region,
+        ?string $profile = null,
+        ?string $accessKey = null,
+        ?string $secretKey = null
+    ) {
         $this->bucket = $bucket;
         $this->region = $region;
 
@@ -28,7 +33,39 @@ class S3Service
             $config['use_aws_shared_config_files'] = true;
         }
 
+        $accessKey = $this->resolveCredential($accessKey, 'AWS_ACCESS_KEY_ID');
+        $secretKey = $this->resolveCredential($secretKey, 'AWS_SECRET_ACCESS_KEY');
+
+        if ($accessKey && $secretKey) {
+            $config['credentials'] = [
+                'key' => $accessKey,
+                'secret' => $secretKey,
+            ];
+        }
+
         $this->s3Client = new S3Client($config);
+    }
+
+    private function resolveCredential(?string $value, string $envKey): ?string
+    {
+        if ($value !== null && $value !== '') {
+            return $value;
+        }
+
+        $envValue = getenv($envKey);
+        if ($envValue !== false && $envValue !== '') {
+            return $envValue;
+        }
+
+        if (isset($_ENV[$envKey]) && $_ENV[$envKey] !== '') {
+            return $_ENV[$envKey];
+        }
+
+        if (isset($_SERVER[$envKey]) && $_SERVER[$envKey] !== '') {
+            return $_SERVER[$envKey];
+        }
+
+        return null;
     }
 
 

--- a/templates/booking/wizard.html.twig
+++ b/templates/booking/wizard.html.twig
@@ -82,6 +82,35 @@
             </div>
 
             <div class="table-card d-none" id="brochure-results-table-wrapper">
+                <div class="table-card-filters" id="brochure-filter-bar">
+                    <div class="table-card-filter-group">
+                        <label for="brochure-filter-deleted" class="form-label mb-1">Brochure status</label>
+                        <select class="form-select form-select-sm" id="brochure-filter-deleted" aria-label="Brochure status">
+                            <option value="active" selected>Active brochures</option>
+                            <option value="deleted">Deleted brochures</option>
+                        </select>
+                    </div>
+                    <div class="table-card-filter-group">
+                        <span class="form-label mb-1 d-block">Time window</span>
+                        <div class="filter-pill-group" role="group" aria-label="Brochure time window">
+                            <div class="filter-pill">
+                                <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-current" name="brochure-filter-time" value="current" checked>
+                                <label class="filter-pill-label" for="brochure-filter-time-current">Current</label>
+                            </div>
+                            <div class="filter-pill">
+                                <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-upcoming" name="brochure-filter-time" value="upcoming" checked>
+                                <label class="filter-pill-label" for="brochure-filter-time-upcoming">Upcoming</label>
+                            </div>
+                            <div class="filter-pill">
+                                <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-past" name="brochure-filter-time" value="past">
+                                <label class="filter-pill-label" for="brochure-filter-time-past">Past</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="table-card-filter-group table-card-filter-reset">
+                        <button type="button" class="btn btn-link btn-sm p-0" id="brochure-filter-reset">Reset filters</button>
+                    </div>
+                </div>
                 <div class="table-card-toolbar">
                     <input type="search" class="form-control table-search" id="brochure-results-search" placeholder="Search brochures" aria-label="Search brochures">
                     <select class="form-select form-select-sm" id="brochure-results-page-size" aria-label="Brochure results per page">

--- a/templates/booking/wizard.html.twig
+++ b/templates/booking/wizard.html.twig
@@ -77,84 +77,96 @@
                 Loading brochures...
             </div>
             <div class="alert alert-danger d-none" role="alert" id="brochure-results-error"></div>
-            <div class="alert alert-warning d-none" role="status" id="brochure-results-empty">
-                No brochures found for the selected company.
-            </div>
-
             <div class="table-card d-none" id="brochure-results-table-wrapper">
                 <div class="table-card-filters" id="brochure-filter-bar">
-                    <div class="table-card-filter-group">
-                        <label for="brochure-filter-deleted" class="form-label mb-1">Brochure status</label>
-                        <select class="form-select form-select-sm" id="brochure-filter-deleted" aria-label="Brochure status">
-                            <option value="active" selected>Active brochures</option>
-                            <option value="deleted">Deleted brochures</option>
-                        </select>
+                    <div class="table-card-filter-legend">
+                        <span class="table-card-filter-title">Brochure filters</span>
+                        <p class="table-card-filter-caption">Pick which brochures you’d like to review before duplicating them.</p>
                     </div>
-                    <div class="table-card-filter-group">
-                        <span class="form-label mb-1 d-block">Time window</span>
-                        <div class="filter-pill-group" role="group" aria-label="Brochure time window">
-                            <div class="filter-pill">
-                                <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-current" name="brochure-filter-time" value="current" checked>
-                                <label class="filter-pill-label" for="brochure-filter-time-current">Current</label>
-                            </div>
-                            <div class="filter-pill">
-                                <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-upcoming" name="brochure-filter-time" value="upcoming" checked>
-                                <label class="filter-pill-label" for="brochure-filter-time-upcoming">Upcoming</label>
-                            </div>
-                            <div class="filter-pill">
-                                <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-past" name="brochure-filter-time" value="past">
-                                <label class="filter-pill-label" for="brochure-filter-time-past">Past</label>
+                    <div class="table-card-filter-controls">
+                        <div class="table-card-filter-group">
+                            <label for="brochure-filter-deleted" class="form-label mb-1">Brochure status</label>
+                            <select class="form-select form-select-sm" id="brochure-filter-deleted" aria-label="Brochure status">
+                                <option value="active" selected>Active brochures</option>
+                                <option value="deleted">Deleted brochures</option>
+                            </select>
+                        </div>
+                        <div class="table-card-filter-group">
+                            <span class="form-label mb-1 d-block">Time window</span>
+                            <div class="filter-pill-group" role="group" aria-label="Brochure time window">
+                                <div class="filter-pill">
+                                    <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-current" name="brochure-filter-time" value="current" checked>
+                                    <label class="filter-pill-label" for="brochure-filter-time-current">Current</label>
+                                </div>
+                                <div class="filter-pill">
+                                    <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-upcoming" name="brochure-filter-time" value="upcoming" checked>
+                                    <label class="filter-pill-label" for="brochure-filter-time-upcoming">Upcoming</label>
+                                </div>
+                                <div class="filter-pill">
+                                    <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-past" name="brochure-filter-time" value="past">
+                                    <label class="filter-pill-label" for="brochure-filter-time-past">Past</label>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="table-card-filter-group table-card-filter-reset">
-                        <button type="button" class="btn btn-link btn-sm p-0" id="brochure-filter-reset">Reset filters</button>
+                        <div class="table-card-filter-group table-card-filter-reset">
+                            <button type="button" class="btn btn-link btn-sm p-0" id="brochure-filter-reset">Reset filters</button>
+                        </div>
                     </div>
                 </div>
-                <div class="table-card-toolbar">
-                    <input type="search" class="form-control table-search" id="brochure-results-search" placeholder="Search brochures" aria-label="Search brochures">
-                    <select class="form-select form-select-sm" id="brochure-results-page-size" aria-label="Brochure results per page">
-                        <option value="5">5 per page</option>
-                        <option value="10" selected>10 per page</option>
-                        <option value="25">25 per page</option>
-                    </select>
+                <div class="table-card-empty-state d-none" id="brochure-results-empty" role="status" aria-live="polite">
+                    <div class="table-card-empty-visual" aria-hidden="true"></div>
+                    <div class="table-card-empty-copy">
+                        <h5>Nothing to show just yet</h5>
+                        <p class="mb-2">No brochures match these filters. Try a different combination or reset to the defaults.</p>
+                        <button type="button" class="btn btn-outline-primary btn-sm" id="brochure-empty-reset">Show active brochures</button>
+                    </div>
                 </div>
-                <div class="table-card-actions" id="brochure-action-bar">
-                    <div class="table-card-actions-group">
-                        <label for="brochure-action-select" class="visually-hidden">Brochure action</label>
-                        <select class="form-select form-select-sm" id="brochure-action-select" aria-label="Select brochure action">
-                            <option value="duplicate_per_store" selected>Duplicate brochures per store</option>
-                            <option value="duplicate_selected_stores">Duplicate brochures per selected store</option>
+                <div class="table-card-body d-none" id="brochure-results-table-container">
+                    <div class="table-card-toolbar">
+                        <input type="search" class="form-control table-search" id="brochure-results-search" placeholder="Search brochures" aria-label="Search brochures">
+                        <select class="form-select form-select-sm" id="brochure-results-page-size" aria-label="Brochure results per page">
+                            <option value="5">5 per page</option>
+                            <option value="10" selected>10 per page</option>
+                            <option value="25">25 per page</option>
                         </select>
                     </div>
-                    <div class="table-card-actions-group brochure-action-stores d-none" id="brochure-action-stores-group">
-                        <label for="brochure-action-selected-stores" class="form-label">Stores</label>
-                        <select class="form-select form-select-sm" id="brochure-action-selected-stores" aria-label="Select stores" multiple data-placeholder="Start typing to search stores"></select>
-                        <small class="form-text text-muted" id="brochure-action-stores-status">Choose a company to load store suggestions.</small>
+                    <div class="table-card-actions" id="brochure-action-bar">
+                        <div class="table-card-actions-group">
+                            <label for="brochure-action-select" class="visually-hidden">Brochure action</label>
+                            <select class="form-select form-select-sm" id="brochure-action-select" aria-label="Select brochure action">
+                                <option value="duplicate_per_store" selected>Duplicate brochures per store</option>
+                                <option value="duplicate_selected_stores">Duplicate brochures per selected store</option>
+                            </select>
+                        </div>
+                        <div class="table-card-actions-group brochure-action-stores d-none" id="brochure-action-stores-group">
+                            <label for="brochure-action-selected-stores" class="form-label">Stores</label>
+                            <select class="form-select form-select-sm" id="brochure-action-selected-stores" aria-label="Select stores" multiple data-placeholder="Start typing to search stores"></select>
+                            <small class="form-text text-muted" id="brochure-action-stores-status">Choose a company to load store suggestions.</small>
+                        </div>
+                        <button type="button" class="btn btn-primary" id="brochure-action-submit">Go baby! Go!</button>
                     </div>
-                    <button type="button" class="btn btn-primary" id="brochure-action-submit">Go baby! Go!</button>
-                </div>
-                <div class="alert d-none" role="alert" id="brochure-action-feedback"></div>
-                <div class="table-responsive">
-                    <table class="table table-hover align-middle" id="brochure-results-table">
-                        <thead>
-                            <tr>
-                                <th scope="col" class="text-center table-selection-header">Select</th>
-                                <th scope="col">ID</th>
-                                <th scope="col">Brochure #</th>
-                                <th scope="col">Type</th>
-                                <th scope="col">Valid Period</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
-                <div class="table-card-footer">
-                    <small id="brochure-results-count" aria-live="polite"></small>
-                    <small id="brochure-selection-count" class="text-muted"></small>
-                    <nav aria-label="Brochure pagination">
-                        <ul class="pagination pagination-sm mb-0" id="brochure-results-pagination"></ul>
-                    </nav>
+                    <div class="alert d-none" role="alert" id="brochure-action-feedback"></div>
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle" id="brochure-results-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col" class="text-center table-selection-header">Select</th>
+                                    <th scope="col">ID</th>
+                                    <th scope="col">Brochure #</th>
+                                    <th scope="col">Type</th>
+                                    <th scope="col">Valid Period</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                    <div class="table-card-footer">
+                        <small id="brochure-results-count" aria-live="polite"></small>
+                        <small id="brochure-selection-count" class="text-muted"></small>
+                        <nav aria-label="Brochure pagination">
+                            <ul class="pagination pagination-sm mb-0" id="brochure-results-pagination"></ul>
+                        </nav>
+                    </div>
                 </div>
             </div>
 

--- a/templates/booking/wizard.html.twig
+++ b/templates/booking/wizard.html.twig
@@ -103,8 +103,8 @@
                                     <label class="filter-pill-label" for="brochure-filter-time-upcoming">Upcoming</label>
                                 </div>
                                 <div class="filter-pill">
-                                    <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-past" name="brochure-filter-time" value="past">
-                                    <label class="filter-pill-label" for="brochure-filter-time-past">Past</label>
+                                    <input type="checkbox" class="filter-pill-input" id="brochure-filter-time-past" name="brochure-filter-time" value="archived">
+                                    <label class="filter-pill-label" for="brochure-filter-time-past">Archived</label>
                                 </div>
                             </div>
                         </div>

--- a/templates/booking/wizard.html.twig
+++ b/templates/booking/wizard.html.twig
@@ -95,7 +95,13 @@
                         <label for="brochure-action-select" class="visually-hidden">Brochure action</label>
                         <select class="form-select form-select-sm" id="brochure-action-select" aria-label="Select brochure action">
                             <option value="duplicate_per_store" selected>Duplicate brochures per store</option>
+                            <option value="duplicate_selected_stores">Duplicate brochures per selected store</option>
                         </select>
+                    </div>
+                    <div class="table-card-actions-group brochure-action-stores d-none" id="brochure-action-stores-group">
+                        <label for="brochure-action-selected-stores" class="form-label">Stores</label>
+                        <select class="form-select form-select-sm" id="brochure-action-selected-stores" aria-label="Select stores" multiple data-placeholder="Start typing to search stores"></select>
+                        <small class="form-text text-muted" id="brochure-action-stores-status">Choose a company to load store suggestions.</small>
                     </div>
                     <button type="button" class="btn btn-primary" id="brochure-action-submit">Go baby! Go!</button>
                 </div>

--- a/tests/Controller/BookingWizardControllerTest.php
+++ b/tests/Controller/BookingWizardControllerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Controller\BookingWizardController;
+use App\Service\IprotoService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\Container;
+
+class BookingWizardControllerTest extends TestCase
+{
+    public function testFetchBrochuresPassesFiltersToService(): void
+    {
+        $request = new Request([
+            'companyId' => '84867',
+            'ownerId' => '1',
+            'deletedFilter' => 'deleted',
+            'timeConstraint' => [
+                'current' => 'true',
+                'past' => '1',
+            ],
+        ]);
+
+        $iprotoService = $this->createMock(IprotoService::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochuresByOwnerAndCompany')
+            ->with(
+                '1',
+                '84867',
+                [
+                    'deletedFilter' => 'deleted',
+                    'timeConstraints' => ['current', 'past'],
+                ],
+            )
+            ->willReturn([
+                ['id' => 1],
+            ]);
+
+        $controller = new BookingWizardController();
+        $controller->setContainer(new Container());
+
+        $response = $controller->fetchBrochures($request, $iprotoService, $logger);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('[{"id":1}]', $response->getContent());
+    }
+
+    public function testFetchBrochuresUsesDefaultFilters(): void
+    {
+        $request = new Request([
+            'companyId' => '84867',
+            'ownerId' => '1',
+        ]);
+
+        $iprotoService = $this->createMock(IprotoService::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochuresByOwnerAndCompany')
+            ->with(
+                '1',
+                '84867',
+                [
+                    'deletedFilter' => 'active',
+                    'timeConstraints' => ['current', 'upcoming'],
+                ],
+            )
+            ->willReturn([]);
+
+        $controller = new BookingWizardController();
+        $controller->setContainer(new Container());
+
+        $response = $controller->fetchBrochures($request, $iprotoService, $logger);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('[]', $response->getContent());
+    }
+}

--- a/tests/Service/BookingWizard/BrochureActionServiceTest.php
+++ b/tests/Service/BookingWizard/BrochureActionServiceTest.php
@@ -372,7 +372,17 @@ class BrochureActionServiceTest extends TestCase
 
         $pdfDir = sys_get_temp_dir() . '/brochure-action/' . uniqid('pdf-', true);
 
-        $service = new BrochureActionService($iprotoService, $csvService, $s3Service, $pdfDir);
+        $service = new BrochureActionService(
+            $iprotoService,
+            $csvService,
+            $s3Service,
+            $pdfDir,
+            static function (int $seconds): void {
+                // no-op for tests
+            },
+            7,
+            0,
+        );
 
         $iprotoService
             ->expects($this->once())
@@ -688,6 +698,16 @@ class BrochureActionServiceTest extends TestCase
 
         $pdfDir ??= sys_get_temp_dir() . '/brochure-action/' . uniqid('', true);
 
-        return new BrochureActionService($iprotoService, $csvService, $s3Service, $pdfDir);
+        return new BrochureActionService(
+            $iprotoService,
+            $csvService,
+            $s3Service,
+            $pdfDir,
+            static function (int $seconds): void {
+                // no-op for tests
+            },
+            7,
+            0,
+        );
     }
 }

--- a/tests/Service/BookingWizard/BrochureActionServiceTest.php
+++ b/tests/Service/BookingWizard/BrochureActionServiceTest.php
@@ -96,6 +96,116 @@ class BrochureActionServiceTest extends TestCase
         $this->assertSame('queued', $result['import']['status']);
     }
 
+    public function testDuplicateBrochuresPerSelectedStoresHonoursStoreSelection(): void
+    {
+        $iprotoService = $this->createMock(IprotoService::class);
+        $csvService = $this->createMock(CsvService::class);
+
+        $service = new BrochureActionService($iprotoService, $csvService);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getStoresByCompany')
+            ->with('42')
+            ->willReturn([
+                ['storeNumber' => '100'],
+                ['storeNumber' => '200'],
+                ['storeNumber' => '300'],
+            ]);
+
+        $brochureDetail = [
+            'id' => '55',
+            'brochureNumber' => 'BR-01',
+            'integration' => '/api/integrations/42',
+        ];
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochureDetails')
+            ->with('55')
+            ->willReturn($brochureDetail);
+
+        $csvService
+            ->expects($this->once())
+            ->method('createCsvFromBrochure')
+            ->with(
+                $this->callback(function ($brochures) {
+                    if (!is_array($brochures) || count($brochures) !== 2) {
+                        return false;
+                    }
+
+                    $first = $brochures[0];
+                    $second = $brochures[1];
+
+                    return $first instanceof Brochure
+                        && $second instanceof Brochure
+                        && $first->getStoreNumber() === '200'
+                        && $first->getBrochureNumber() === 'BR-01_200'
+                        && $second->getStoreNumber() === '100'
+                        && $second->getBrochureNumber() === 'BR-01_100';
+                }),
+                '42'
+            )
+            ->willReturn([
+                'companyId' => '42',
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('importData')
+            ->with([
+                'companyId' => '42',
+            ])
+            ->willReturn([
+                '@id' => '/api/imports/100',
+                'status' => 'queued',
+            ]);
+
+        $result = $service->duplicateBrochuresPerSelectedStores('42', '9', ['55'], ['200', '100', '100']);
+
+        $this->assertSame(1, $result['summary']['selectedBrochures']);
+        $this->assertSame(2, $result['summary']['stores']);
+        $this->assertSame(2, $result['summary']['generated']);
+    }
+
+    public function testDuplicateBrochuresPerSelectedStoresRejectsUnknownStores(): void
+    {
+        $iprotoService = $this->createMock(IprotoService::class);
+        $csvService = $this->createMock(CsvService::class);
+
+        $service = new BrochureActionService($iprotoService, $csvService);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getStoresByCompany')
+            ->with('42')
+            ->willReturn([
+                ['storeNumber' => '100'],
+            ]);
+
+        $iprotoService
+            ->expects($this->never())
+            ->method('getBrochureDetails');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('not available');
+
+        $service->duplicateBrochuresPerSelectedStores('42', '9', ['55'], ['999']);
+    }
+
+    public function testDuplicateBrochuresPerSelectedStoresRequiresSelection(): void
+    {
+        $service = new BrochureActionService(
+            $this->createMock(IprotoService::class),
+            $this->createMock(CsvService::class)
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Select at least one store');
+
+        $service->duplicateBrochuresPerSelectedStores('42', '9', ['55'], []);
+    }
+
     public function testDuplicateBrochuresPerStoreRequiresSelection(): void
     {
         $service = new BrochureActionService(

--- a/tests/Service/BookingWizard/BrochureActionServiceTest.php
+++ b/tests/Service/BookingWizard/BrochureActionServiceTest.php
@@ -401,14 +401,15 @@ class BrochureActionServiceTest extends TestCase
                 $this->callback(function (string $destination) use ($pdfDir) {
                     $this->assertStringStartsWith($pdfDir, $destination);
                     return true;
-                })
+                }),
+                '55'
             )
-            ->willReturnCallback(static function (string $pageId, string $destination): string {
+            ->willReturnCallback(static function (string $pageId, string $destination, string $brochureId): string {
                 if (!is_dir(dirname($destination))) {
                     mkdir(dirname($destination), 0755, true);
                 }
 
-                file_put_contents($destination, 'PDF-' . $pageId);
+                file_put_contents($destination, 'PDF-' . $pageId . '-' . $brochureId);
 
                 return $destination;
             });
@@ -422,7 +423,7 @@ class BrochureActionServiceTest extends TestCase
 
                 return true;
             }))
-            ->willReturn('https://s3.example/brochure_1442340.pdf');
+            ->willReturn('https://s3.example/brochure_55.pdf');
 
         $csvService
             ->expects($this->once())
@@ -433,8 +434,8 @@ class BrochureActionServiceTest extends TestCase
                     $first = $brochures[0];
                     $second = $brochures[1];
 
-                    $this->assertSame('https://s3.example/brochure_1442340.pdf', $first->getPdfUrl());
-                    $this->assertSame('https://s3.example/brochure_1442340.pdf', $second->getPdfUrl());
+                    $this->assertSame('https://s3.example/brochure_55.pdf', $first->getPdfUrl());
+                    $this->assertSame('https://s3.example/brochure_55.pdf', $second->getPdfUrl());
 
                     return true;
                 }),

--- a/tests/Service/BookingWizard/BrochureActionServiceTest.php
+++ b/tests/Service/BookingWizard/BrochureActionServiceTest.php
@@ -9,6 +9,7 @@ use App\Service\BookingWizard\BrochureActionService;
 use App\Service\CsvService;
 use App\Service\IprotoService;
 use PHPUnit\Framework\TestCase;
+use function mb_check_encoding;
 
 class BrochureActionServiceTest extends TestCase
 {
@@ -163,6 +164,130 @@ class BrochureActionServiceTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Failed to import duplicated brochures.');
+
+        $service->duplicateBrochuresPerStore('42', '9', ['55']);
+    }
+
+    public function testDuplicateBrochuresPerStoreSanitizesInvalidStrings(): void
+    {
+        $iprotoService = $this->createMock(IprotoService::class);
+        $csvService = $this->createMock(CsvService::class);
+
+        $service = new BrochureActionService($iprotoService, $csvService);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getStoresByCompany')
+            ->with('42')
+            ->willReturn([
+                ['storeNumber' => '100'],
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochureDetails')
+            ->with('55')
+            ->willReturn([
+                'id' => '55',
+                'brochureNumber' => 'BR-Ü',
+                'title' => "Sommer Angebote \xC3\x28",
+                'tags' => [
+                    ['name' => 'Promo'],
+                    ['title' => "Sonder \xC3\x28"],
+                ],
+                'trackingPixels' => [
+                    ['url' => 'https://tracker.example/pixel?a=1'],
+                    ['code' => '<script>track()</script>'],
+                ],
+                'pages' => [
+                    ['pdfUrl' => 'https://cdn.example/brochure.pdf'],
+                ],
+                'integration' => '/api/integrations/42',
+            ]);
+
+        $csvService
+            ->expects($this->once())
+            ->method('createCsvFromBrochure')
+            ->with(
+                $this->callback(function ($brochures) {
+                    $this->assertIsArray($brochures);
+                    $this->assertCount(1, $brochures);
+                    $brochure = $brochures[0];
+                    $this->assertInstanceOf(Brochure::class, $brochure);
+                    $this->assertSame('BR-Ü_100', $brochure->getBrochureNumber());
+                    $this->assertSame('https://cdn.example/brochure.pdf', $brochure->getPdfUrl());
+                    $this->assertTrue(mb_check_encoding($brochure->getTitle(), 'UTF-8'));
+                    $this->assertStringNotContainsString("\xC3\x28", $brochure->getTitle());
+                    $this->assertSame(
+                        "https://tracker.example/pixel?a=1\n<script>track()</script>",
+                        $brochure->getTrackingPixels()
+                    );
+                    $tags = $brochure->getTags();
+                    $this->assertTrue(mb_check_encoding($tags, 'UTF-8'));
+                    $this->assertStringContainsString('Promo', $tags);
+                    $this->assertStringContainsString('Sonder', $tags);
+                    $this->assertStringNotContainsString("\xC3\x28", $tags);
+
+                    return true;
+                }),
+                '42'
+            )
+            ->willReturn([
+                'companyId' => '42',
+                'type' => 'brochures',
+                'base64' => 'ZHVtbXk=',
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('importData')
+            ->willReturn([
+                '@id' => '/api/imports/999',
+                'status' => 'queued',
+            ]);
+
+        $result = $service->duplicateBrochuresPerStore('42', '9', ['55']);
+
+        $this->assertSame('999', $result['importId']);
+        $this->assertSame('queued', $result['import']['status']);
+    }
+
+    public function testDuplicateBrochuresPerStoreWrapsCsvFailures(): void
+    {
+        $iprotoService = $this->createMock(IprotoService::class);
+        $csvService = $this->createMock(CsvService::class);
+
+        $service = new BrochureActionService($iprotoService, $csvService);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getStoresByCompany')
+            ->with('42')
+            ->willReturn([
+                ['storeNumber' => '100'],
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochureDetails')
+            ->with('55')
+            ->willReturn([
+                'id' => '55',
+                'brochureNumber' => 'BR-01',
+                'integration' => '/api/integrations/42',
+            ]);
+
+        $csvService
+            ->expects($this->once())
+            ->method('createCsvFromBrochure')
+            ->willThrowException(new \Exception('csv exploded'));
+
+        $iprotoService
+            ->expects($this->never())
+            ->method('importData');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to create brochure CSV for duplication.');
 
         $service->duplicateBrochuresPerStore('42', '9', ['55']);
     }

--- a/tests/Service/BookingWizard/BrochureActionServiceTest.php
+++ b/tests/Service/BookingWizard/BrochureActionServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Service\BookingWizard;
 
 use App\Dto\Brochure;
+use App\Dto\Product;
 use App\Service\BookingWizard\BrochureActionService;
 use App\Service\CsvService;
 use App\Service\IprotoService;
@@ -457,6 +458,178 @@ class BrochureActionServiceTest extends TestCase
 
         $this->assertSame('888', $result['importId']);
         $this->assertSame('queued', $result['import']['status']);
+    }
+
+    public function testDuplicateDiscoverBrochuresDuplicateProductsPerStore(): void
+    {
+        $iprotoService = $this->createMock(IprotoService::class);
+        $csvService = $this->createMock(CsvService::class);
+
+        $service = $this->createBrochureActionService($iprotoService, $csvService);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getStoresByCompany')
+            ->with('42')
+            ->willReturn([
+                ['storeNumber' => '100'],
+                ['storeNumber' => '200'],
+            ]);
+
+        $layout = [
+            '3' => [
+                'pages' => [
+                    [
+                        'modules' => [
+                            [
+                                'name' => 'product_slot',
+                                'products' => [
+                                    ['id' => 11],
+                                    ['id' => 22],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $brochureDetail = [
+            'id' => '55',
+            'brochureNumber' => 'DISC-01',
+            'integration' => '/api/integrations/42',
+            'type' => 'discover',
+            'layout' => json_encode($layout, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochureDetails')
+            ->with('55')
+            ->willReturn($brochureDetail);
+
+        $iprotoService
+            ->expects($this->exactly(2))
+            ->method('getProduct')
+            ->willReturnMap([
+                [11, ['productNumber' => 'P-11', 'integration' => '/api/integrations/42']],
+                [22, ['productNumber' => 'P-22', 'integration' => '/api/integrations/42']],
+            ]);
+
+        $csvService
+            ->expects($this->once())
+            ->method('createCsvFromProducts')
+            ->with(
+                $this->callback(function (array $products): bool {
+                    if (count($products) !== 4) {
+                        return false;
+                    }
+
+                    $numbers = array_map(static function (Product $product): string {
+                        return $product->getProductNumber();
+                    }, $products);
+
+                    sort($numbers);
+
+                    return $numbers === ['P-11_100', 'P-11_200', 'P-22_100', 'P-22_200'];
+                }),
+                '42'
+            )
+            ->willReturn([
+                'type' => 'products',
+                'companyId' => '42',
+                'base64' => 'products',
+            ]);
+
+        $iprotoService
+            ->expects($this->exactly(2))
+            ->method('importData')
+            ->willReturnOnConsecutiveCalls(
+                ['@id' => '/api/imports/555'],
+                ['@id' => '/api/imports/999', 'status' => 'queued']
+            );
+
+        $iprotoService
+            ->expects($this->exactly(4))
+            ->method('findProductsByNumber')
+            ->willReturnMap([
+                ['42', 'P-11_100', ['id' => 1011]],
+                ['42', 'P-11_200', ['id' => 2011]],
+                ['42', 'P-22_100', ['id' => 1022]],
+                ['42', 'P-22_200', ['id' => 2022]],
+            ]);
+
+        $csvService
+            ->expects($this->once())
+            ->method('createCsvFromBrochure')
+            ->with(
+                $this->callback(function (array $brochures): bool {
+                    if (count($brochures) !== 2) {
+                        return false;
+                    }
+
+                    $expectedLayouts = [
+                        '100' => [1011, 1022],
+                        '200' => [2011, 2022],
+                    ];
+
+                    foreach ($brochures as $brochure) {
+                        if (!$brochure instanceof Brochure) {
+                            return false;
+                        }
+
+                        $decoded = json_decode($brochure->getLayout(), true);
+                        if (!is_array($decoded)) {
+                            return false;
+                        }
+
+                        $ids = [];
+                        foreach ($decoded as $block) {
+                            if (!is_array($block)) {
+                                continue;
+                            }
+
+                            foreach ($block['pages'] ?? [] as $page) {
+                                if (!is_array($page)) {
+                                    continue;
+                                }
+
+                                foreach ($page['modules'] ?? [] as $module) {
+                                    if (!is_array($module)) {
+                                        continue;
+                                    }
+
+                                    foreach ($module['products'] ?? [] as $product) {
+                                        if (is_array($product) && isset($product['id'])) {
+                                            $ids[] = $product['id'];
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        sort($ids);
+
+                        $storeNumber = $brochure->getStoreNumber();
+
+                        if (!isset($expectedLayouts[$storeNumber]) || $ids !== $expectedLayouts[$storeNumber]) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }),
+                '42'
+            )
+            ->willReturn([
+                'downloadLink' => 'https://example.com/brochures.csv',
+            ]);
+
+        $result = $service->duplicateBrochuresPerStore('42', '9', ['55']);
+
+        $this->assertSame('999', $result['importId']);
+        $this->assertSame(2, $result['summary']['stores']);
+        $this->assertSame(2, $result['summary']['generated']);
     }
 
     public function testDuplicateBrochuresPerStoreWrapsCsvFailures(): void

--- a/tests/Service/BookingWizard/BrochureActionServiceTest.php
+++ b/tests/Service/BookingWizard/BrochureActionServiceTest.php
@@ -120,4 +120,50 @@ class BrochureActionServiceTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $service->duplicateBrochuresPerStore('42', '9', ['1']);
     }
+
+    public function testDuplicateBrochuresPerStoreWrapsImportFailures(): void
+    {
+        $iprotoService = $this->createMock(IprotoService::class);
+        $csvService = $this->createMock(CsvService::class);
+
+        $service = new BrochureActionService($iprotoService, $csvService);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getStoresByCompany')
+            ->with('42')
+            ->willReturn([
+                ['storeNumber' => '100'],
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochureDetails')
+            ->with('55')
+            ->willReturn([
+                'id' => '55',
+                'brochureNumber' => 'BR-01',
+                'integration' => '/api/integrations/42',
+            ]);
+
+        $csvService
+            ->expects($this->once())
+            ->method('createCsvFromBrochure')
+            ->with($this->isType('array'), '42')
+            ->willReturn([
+                'companyId' => '42',
+                'type' => 'brochures',
+                'base64' => 'ZHVtbXk=',
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('importData')
+            ->willThrowException(new \TypeError('Boom'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to import duplicated brochures.');
+
+        $service->duplicateBrochuresPerStore('42', '9', ['55']);
+    }
 }

--- a/tests/Service/BookingWizard/BrochureActionServiceTest.php
+++ b/tests/Service/BookingWizard/BrochureActionServiceTest.php
@@ -8,6 +8,7 @@ use App\Dto\Brochure;
 use App\Service\BookingWizard\BrochureActionService;
 use App\Service\CsvService;
 use App\Service\IprotoService;
+use App\Service\S3Service;
 use PHPUnit\Framework\TestCase;
 use function mb_check_encoding;
 
@@ -18,7 +19,7 @@ class BrochureActionServiceTest extends TestCase
         $iprotoService = $this->createMock(IprotoService::class);
         $csvService = $this->createMock(CsvService::class);
 
-        $service = new BrochureActionService($iprotoService, $csvService);
+        $service = $this->createBrochureActionService($iprotoService, $csvService);
 
         $iprotoService
             ->expects($this->once())
@@ -101,7 +102,7 @@ class BrochureActionServiceTest extends TestCase
         $iprotoService = $this->createMock(IprotoService::class);
         $csvService = $this->createMock(CsvService::class);
 
-        $service = new BrochureActionService($iprotoService, $csvService);
+        $service = $this->createBrochureActionService($iprotoService, $csvService);
 
         $iprotoService
             ->expects($this->once())
@@ -173,7 +174,7 @@ class BrochureActionServiceTest extends TestCase
         $iprotoService = $this->createMock(IprotoService::class);
         $csvService = $this->createMock(CsvService::class);
 
-        $service = new BrochureActionService($iprotoService, $csvService);
+        $service = $this->createBrochureActionService($iprotoService, $csvService);
 
         $iprotoService
             ->expects($this->once())
@@ -195,7 +196,7 @@ class BrochureActionServiceTest extends TestCase
 
     public function testDuplicateBrochuresPerSelectedStoresRequiresSelection(): void
     {
-        $service = new BrochureActionService(
+        $service = $this->createBrochureActionService(
             $this->createMock(IprotoService::class),
             $this->createMock(CsvService::class)
         );
@@ -208,7 +209,7 @@ class BrochureActionServiceTest extends TestCase
 
     public function testDuplicateBrochuresPerStoreRequiresSelection(): void
     {
-        $service = new BrochureActionService(
+        $service = $this->createBrochureActionService(
             $this->createMock(IprotoService::class),
             $this->createMock(CsvService::class)
         );
@@ -226,7 +227,7 @@ class BrochureActionServiceTest extends TestCase
             ->with('42')
             ->willReturn([]);
 
-        $service = new BrochureActionService($iprotoService, $this->createMock(CsvService::class));
+        $service = $this->createBrochureActionService($iprotoService, $this->createMock(CsvService::class));
 
         $this->expectException(\RuntimeException::class);
         $service->duplicateBrochuresPerStore('42', '9', ['1']);
@@ -237,7 +238,7 @@ class BrochureActionServiceTest extends TestCase
         $iprotoService = $this->createMock(IprotoService::class);
         $csvService = $this->createMock(CsvService::class);
 
-        $service = new BrochureActionService($iprotoService, $csvService);
+        $service = $this->createBrochureActionService($iprotoService, $csvService);
 
         $iprotoService
             ->expects($this->once())
@@ -283,7 +284,7 @@ class BrochureActionServiceTest extends TestCase
         $iprotoService = $this->createMock(IprotoService::class);
         $csvService = $this->createMock(CsvService::class);
 
-        $service = new BrochureActionService($iprotoService, $csvService);
+        $service = $this->createBrochureActionService($iprotoService, $csvService);
 
         $iprotoService
             ->expects($this->once())
@@ -362,12 +363,107 @@ class BrochureActionServiceTest extends TestCase
         $this->assertSame('queued', $result['import']['status']);
     }
 
+    public function testDuplicateBrochuresPerStoreUploadsPdfToS3WhenBrochurePageUrlProvided(): void
+    {
+        $iprotoService = $this->createMock(IprotoService::class);
+        $csvService = $this->createMock(CsvService::class);
+        $s3Service = $this->createMock(S3Service::class);
+
+        $pdfDir = sys_get_temp_dir() . '/brochure-action/' . uniqid('pdf-', true);
+
+        $service = new BrochureActionService($iprotoService, $csvService, $s3Service, $pdfDir);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getStoresByCompany')
+            ->with('42')
+            ->willReturn([
+                ['storeNumber' => '100'],
+                ['storeNumber' => '200'],
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('getBrochureDetails')
+            ->with('55')
+            ->willReturn([
+                'id' => '55',
+                'brochureNumber' => 'BR-01',
+                'integration' => '/api/integrations/42',
+                'pdfUrl' => '/api/brochure_pages/1442340',
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('downloadBrochurePdf')
+            ->with(
+                '1442340',
+                $this->callback(function (string $destination) use ($pdfDir) {
+                    $this->assertStringStartsWith($pdfDir, $destination);
+                    return true;
+                })
+            )
+            ->willReturnCallback(static function (string $pageId, string $destination): string {
+                if (!is_dir(dirname($destination))) {
+                    mkdir(dirname($destination), 0755, true);
+                }
+
+                file_put_contents($destination, 'PDF-' . $pageId);
+
+                return $destination;
+            });
+
+        $s3Service
+            ->expects($this->once())
+            ->method('upload')
+            ->with($this->callback(function (string $localPath) use ($pdfDir) {
+                $this->assertStringStartsWith($pdfDir, $localPath);
+                $this->assertFileExists($localPath);
+
+                return true;
+            }))
+            ->willReturn('https://s3.example/brochure_1442340.pdf');
+
+        $csvService
+            ->expects($this->once())
+            ->method('createCsvFromBrochure')
+            ->with(
+                $this->callback(function (array $brochures) {
+                    $this->assertCount(2, $brochures);
+                    $first = $brochures[0];
+                    $second = $brochures[1];
+
+                    $this->assertSame('https://s3.example/brochure_1442340.pdf', $first->getPdfUrl());
+                    $this->assertSame('https://s3.example/brochure_1442340.pdf', $second->getPdfUrl());
+
+                    return true;
+                }),
+                '42'
+            )
+            ->willReturn([
+                'downloadLink' => 'https://example.com/brochures.csv',
+            ]);
+
+        $iprotoService
+            ->expects($this->once())
+            ->method('importData')
+            ->willReturn([
+                '@id' => '/api/imports/888',
+                'status' => 'queued',
+            ]);
+
+        $result = $service->duplicateBrochuresPerStore('42', '9', ['55']);
+
+        $this->assertSame('888', $result['importId']);
+        $this->assertSame('queued', $result['import']['status']);
+    }
+
     public function testDuplicateBrochuresPerStoreWrapsCsvFailures(): void
     {
         $iprotoService = $this->createMock(IprotoService::class);
         $csvService = $this->createMock(CsvService::class);
 
-        $service = new BrochureActionService($iprotoService, $csvService);
+        $service = $this->createBrochureActionService($iprotoService, $csvService);
 
         $iprotoService
             ->expects($this->once())
@@ -400,5 +496,24 @@ class BrochureActionServiceTest extends TestCase
         $this->expectExceptionMessage('Failed to create brochure CSV for duplication.');
 
         $service->duplicateBrochuresPerStore('42', '9', ['55']);
+    }
+
+    private function createBrochureActionService(
+        ?IprotoService $iprotoService = null,
+        ?CsvService $csvService = null,
+        ?S3Service $s3Service = null,
+        ?string $pdfDir = null
+    ): BrochureActionService {
+        $iprotoService ??= $this->createMock(IprotoService::class);
+        $csvService ??= $this->createMock(CsvService::class);
+        $s3Service ??= $this->createMock(S3Service::class);
+
+        $s3Service->method('upload')->willReturnCallback(
+            static fn (string $path): string => 'https://s3.example/' . basename($path)
+        );
+
+        $pdfDir ??= sys_get_temp_dir() . '/brochure-action/' . uniqid('', true);
+
+        return new BrochureActionService($iprotoService, $csvService, $s3Service, $pdfDir);
     }
 }


### PR DESCRIPTION
## Summary
- wrap the iProto import call in the brochure duplication service so TypeErrors surface as runtime exceptions with a helpful message
- ensure the iProto service rejects non-array import responses instead of returning invalid data
- add a regression test covering the new error handling path when imports fail

## Testing
- ./vendor/bin/simple-phpunit

------
https://chatgpt.com/codex/tasks/task_b_68d539c2fe4483319905c5ce2f6832dd